### PR TITLE
fix: derive deterministic DocumentIds in $meshState so reloads keep their data

### DIFF
--- a/src/shared/lib/mesh-state.ts
+++ b/src/shared/lib/mesh-state.ts
@@ -14,10 +14,15 @@
  *      belongs to.
  *
  *   2. A handle factory that resolves the application's logical key to an
- *      Automerge DocumentId via a per-Repo key map, identical in shape to
- *      the $peerState factory but registered against a separate Repo
- *      configured for the mesh transport (signed and encrypted at the
- *      network layer).
+ *      Automerge DocumentId by hashing the key into a deterministic,
+ *      content-addressable id. Every Repo backed by the same storage lands
+ *      on the same document without needing any extra state, and two devices
+ *      that have never met converge on the same id for the same key — which
+ *      also helps first-sync after pairing. (Prior to this change the factory
+ *      held an in-memory per-Repo `Map<string, DocumentId>`, which meant that
+ *      a lone-device reload — a very common onboarding state — produced a
+ *      fresh DocumentId for the same logical key, orphaned the document the
+ *      storage adapter still held on disk, and silently lost the user's data.)
  *
  *   3. Signing and encryption are mandatory, not optional. Where $peerState
  *      accepts encrypt/sign as opt-in flags (currently throwing in Phase 1),
@@ -33,7 +38,15 @@
  * loopback adapter pair satisfies the same contract.
  */
 
-import type { DocHandle, DocumentId, Repo } from "@automerge/automerge-repo/slim";
+import {
+  Automerge,
+  type BinaryDocumentId,
+  type DocHandle,
+  type DocumentId,
+  interpretAsDocumentId,
+  type Repo,
+} from "@automerge/automerge-repo/slim";
+import nacl from "tweetnacl";
 import type { Access } from "./access";
 import {
   $crdtCounter,
@@ -62,22 +75,16 @@ export interface MeshStateOptions {
   access?: Access;
 }
 
-/** Internal: per-Repo key → DocumentId map. */
-const keyMapsByRepo = new WeakMap<Repo, Map<string, DocumentId>>();
 let defaultRepo: Repo | undefined;
 
 /**
  * Set the default Repo that the $mesh* primitives use when no `repo` option
- * is supplied. Calling this with a new Repo clears the per-Repo key map so
- * that tests start each scenario with a fresh document space.
- *
- * Production code typically calls this once at application startup with a
- * Repo configured for the mesh transport. Tests call it before each
- * scenario with an in-memory or loopback Repo.
+ * is supplied. Production code typically calls this once at application
+ * startup with a Repo configured for the mesh transport. Tests call it
+ * before each scenario with an in-memory or loopback Repo.
  */
 export function configureMeshState(repo: Repo): void {
   defaultRepo = repo;
-  keyMapsByRepo.set(repo, new Map());
 }
 
 /**
@@ -98,28 +105,54 @@ function resolveRepo(option: Repo | undefined): Repo {
   return repo;
 }
 
-function getKeyMap(repo: Repo): Map<string, DocumentId> {
-  let map = keyMapsByRepo.get(repo);
-  if (!map) {
-    map = new Map();
-    keyMapsByRepo.set(repo, map);
-  }
-  return map;
+/**
+ * Domain-separated hash of an application key into a 16-byte
+ * {@link BinaryDocumentId}. SHA-512 via tweetnacl (already a dep for signing);
+ * the first 16 bytes give a DocumentId with uniform distribution across the
+ * Automerge id space. The domain prefix pins the derivation to $meshState so
+ * that the same logical key used in a different Polly subsystem would
+ * produce a different id.
+ */
+const DOC_ID_DOMAIN = "polly/meshState/v1";
+const keyEncoder = new TextEncoder();
+
+function deriveDocumentId(key: string): DocumentId {
+  const digest = nacl.hash(keyEncoder.encode(`${DOC_ID_DOMAIN}:${key}`));
+  const bytes = digest.slice(0, 16);
+  return interpretAsDocumentId(bytes as unknown as BinaryDocumentId);
 }
 
+/**
+ * Build a getHandle factory that resolves a logical key to a DocHandle on
+ * the supplied Repo via a deterministic DocumentId. On the first call during
+ * a process lifetime — whether the device has never written this key or has
+ * written it before a prior reload — the factory short-circuits around
+ * {@link Repo.find}'s network-request timeout: it peeks directly at the
+ * Repo's storage subsystem, hydrates from storage if the bytes are there,
+ * and otherwise seeds a fresh document at the deterministic id. Subsequent
+ * calls in the same process return the cached handle.
+ */
 function buildHandleFactory<D>(
   repo: Repo,
   key: string,
   initialDoc: D
 ): () => Promise<DocHandle<D>> {
+  const documentId = deriveDocumentId(key);
   return async () => {
-    const map = getKeyMap(repo);
-    const existingId = map.get(key);
-    if (existingId !== undefined) {
-      return repo.find<D>(existingId);
+    const cached = repo.handles[documentId];
+    if (cached) {
+      await cached.whenReady(["ready", "unavailable"]);
+      if (cached.state === "ready") {
+        return cached as unknown as DocHandle<D>;
+      }
     }
-    const handle = repo.create<D>(initialDoc);
-    map.set(key, handle.documentId);
+    const stored = await repo.storageSubsystem?.loadDoc<D>(documentId);
+    if (stored) {
+      return repo.find<D>(documentId, { allowableStates: ["ready"] });
+    }
+    const seeded = Automerge.save(Automerge.from(initialDoc as unknown as Record<string, unknown>));
+    const handle = repo.import<D>(seeded, { docId: documentId });
+    handle.doneLoading();
     return handle;
   };
 }

--- a/tests/unit/mesh-state-persistence.test.ts
+++ b/tests/unit/mesh-state-persistence.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression coverage for Polly issue #52 — $meshState on a lone device
+ * lost its data on every page reload because the key → DocumentId map was
+ * an in-memory WeakMap that vanished with the Repo. The document bytes
+ * survived in the Automerge-Repo storage adapter; the lookup did not.
+ *
+ * These tests drive the single-device path:
+ *   - write via $meshState against Repo A (holding a storage adapter),
+ *   - flush the Repo so the writes reach the adapter,
+ *   - drop Repo A and construct a fresh Repo B on the same adapter,
+ *   - read via $meshState and assert the write is visible.
+ *
+ * The shared InMemoryStorage implements the full
+ * `StorageAdapterInterface` so both Repos see the same byte store. With
+ * the pre-#52 in-memory key map, Repo B produced a fresh DocumentId for
+ * the same logical key and the expectation failed on an empty initial
+ * value. With the fix in place the DocumentId is derived
+ * deterministically from the key and Repo B hydrates from storage.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Chunk, StorageKey } from "@automerge/automerge-repo";
+import { Repo, type StorageAdapterInterface } from "@automerge/automerge-repo";
+import {
+  $meshCounter,
+  $meshState,
+  configureMeshState,
+  resetMeshState,
+} from "@/shared/lib/mesh-state";
+import { migrationRegistry } from "@/shared/lib/migrate-primitive";
+import { primitiveRegistry } from "@/shared/lib/primitive-registry";
+import type { VersionedDoc } from "@/shared/lib/schema-version";
+
+type Tasks = VersionedDoc & { items: string[] };
+
+/**
+ * Minimal in-memory Automerge-Repo storage adapter. Keys are joined with
+ * a separator that cannot appear inside a path segment, so the store is a
+ * flat Map. `loadRange` and `removeRange` scan the keys; production
+ * adapters use prefix indexes, but the test suite never has more than a
+ * handful of chunks per doc so a scan is fine.
+ */
+class InMemoryStorage implements StorageAdapterInterface {
+  private readonly chunks = new Map<string, Uint8Array>();
+
+  private join(key: StorageKey): string {
+    return key.join("\u0000");
+  }
+
+  async load(key: StorageKey): Promise<Uint8Array | undefined> {
+    return this.chunks.get(this.join(key));
+  }
+
+  async save(key: StorageKey, data: Uint8Array): Promise<void> {
+    this.chunks.set(this.join(key), data);
+  }
+
+  async remove(key: StorageKey): Promise<void> {
+    this.chunks.delete(this.join(key));
+  }
+
+  async loadRange(prefix: StorageKey): Promise<Chunk[]> {
+    const needle = this.join(prefix);
+    const results: Chunk[] = [];
+    for (const [joined, data] of this.chunks) {
+      if (joined === needle || joined.startsWith(`${needle}\u0000`)) {
+        results.push({ key: joined.split("\u0000"), data });
+      }
+    }
+    return results;
+  }
+
+  async removeRange(prefix: StorageKey): Promise<void> {
+    const needle = this.join(prefix);
+    for (const joined of [...this.chunks.keys()]) {
+      if (joined === needle || joined.startsWith(`${needle}\u0000`)) {
+        this.chunks.delete(joined);
+      }
+    }
+  }
+}
+
+const activeRepos: Repo[] = [];
+
+function makeRepo(storage: StorageAdapterInterface): Repo {
+  const repo = new Repo({ network: [], storage });
+  activeRepos.push(repo);
+  return repo;
+}
+
+beforeEach(() => {
+  primitiveRegistry.clear();
+  migrationRegistry.clear();
+});
+
+afterEach(async () => {
+  resetMeshState();
+  primitiveRegistry.clear();
+  migrationRegistry.clear();
+  for (const repo of activeRepos) {
+    try {
+      await repo.shutdown();
+    } catch {
+      // best effort
+    }
+  }
+  activeRepos.length = 0;
+});
+
+describe("$meshState — lone-device persistence across Repo restart", () => {
+  test("state written on one Repo survives a reload on a new Repo backed by the same storage", async () => {
+    const storage = new InMemoryStorage();
+
+    const repoA = makeRepo(storage);
+    configureMeshState(repoA);
+    const writer = $meshState<Tasks>("tasks", { items: [] });
+    await writer.loaded;
+    writer.value = { items: ["first", "second"] };
+    // Let the storage subsystem pick up the signal's write before flushing.
+    await new Promise((r) => setTimeout(r, 0));
+    await repoA.flush();
+
+    resetMeshState();
+    primitiveRegistry.clear();
+    migrationRegistry.clear();
+
+    const repoB = makeRepo(storage);
+    configureMeshState(repoB);
+    const reader = $meshState<Tasks>("tasks", { items: [] });
+    await reader.loaded;
+
+    expect(reader.value.items).toEqual(["first", "second"]);
+  });
+
+  test("$meshCounter on a lone device recovers its value across a reload", async () => {
+    const storage = new InMemoryStorage();
+
+    const repoA = makeRepo(storage);
+    configureMeshState(repoA);
+    const a = $meshCounter("visits", 0);
+    await a.loaded;
+    a.value = 3;
+    await new Promise((r) => setTimeout(r, 0));
+    await repoA.flush();
+
+    resetMeshState();
+    primitiveRegistry.clear();
+    migrationRegistry.clear();
+
+    const repoB = makeRepo(storage);
+    configureMeshState(repoB);
+    const b = $meshCounter("visits", 0);
+    await b.loaded;
+
+    expect(b.value).toBe(3);
+  });
+
+  test("a fresh key on a repo without storage seeds without waiting for the unavailable timeout", async () => {
+    const repo = new Repo({ network: [] });
+    activeRepos.push(repo);
+    configureMeshState(repo);
+
+    const started = Date.now();
+    const prim = $meshState<Tasks>("fresh", { items: ["seed"] });
+    await prim.loaded;
+    const elapsed = Date.now() - started;
+
+    // The unavailable-transition timeout is 60s; if the factory were waiting
+    // for it, we'd never finish this test. Allow generous slack — anything
+    // well under a second is proof the short-circuit path fired.
+    expect(elapsed).toBeLessThan(2000);
+    expect(prim.value.items).toEqual(["seed"]);
+  });
+});


### PR DESCRIPTION
Closes #52.

## Summary

A device with no paired peers lost every `$meshState` write on reload. The Automerge bytes survived in the storage adapter, but the key → DocumentId map lived in an in-memory `WeakMap<Repo, Map<string, DocumentId>>`, so a fresh Repo produced a fresh DocumentId for the same logical key and the old document became unreachable. Paired peers hid the bug in production because the new Repo could pull the correct id back through sync; lone devices — the common first-run state — could not.

The factory now hashes each key through tweetnacl's SHA-512 with a `polly/meshState/v1` domain prefix, takes the first sixteen bytes, and treats the result as the DocumentId. Every Repo backed by the same storage lands on the same document; two devices that have never met converge on the same id for the same key, which also helps the first sync after pairing.

Finding the handle goes through three paths. If a handle for the derived id is already cached on the Repo the factory awaits and returns it. If the Repo's storage subsystem holds the bytes the factory hydrates through `Repo.find`. Otherwise it seeds a fresh Automerge document at the deterministic id via `repo.import` and marks it ready, which bypasses `Repo.find`'s sixty-second unavailable-transition wait on first use.

The companion test walks the reload path end-to-end against a shared in-memory storage adapter, and a second test asserts the no-storage seed path completes immediately rather than waiting on the network timeout.

## Follow-up

`$peerState` carries the same shape of bug. Paired clients and the server-as-peer hide it in most deployments, but a lone offline client would lose data across reloads for identical reasons. A follow-up PR will port the derivation helper into `peer-state.ts`.