### PR TITLE
feat: $fairfox/polly/actions + /ui + actions-driven-app recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2026-04-17
+
+### Fixed
+
+- `@fairfox/polly/elysia` no longer forces a static import of
+  `@automerge/automerge-repo`, `@automerge/automerge-repo-network-websocket`,
+  `@automerge/automerge-repo-storage-nodefs`, and `ws` through its barrel.
+  The `createPeerRepoServer` factory now pulls those peer-state dependencies
+  dynamically inside the function body, so Elysia apps that use only the
+  non-peer surface (the `polly()` plugin) evaluate the module without the
+  peer packages installed. Apps that actually build a peer-relay server
+  still need the packages — they're loaded when `createPeerRepoServer` runs
+  — and the public type surface is unchanged.
+
 ## [0.25.0] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,16 @@ time-varying selectors, commits baselines under
 baselines locally; the harness refuses that env var when `CI=true`
 to prevent silently-drifted baselines from landing.
 
+#### Browser test runner shipped as `polly test:browser`
+
+The Puppeteer-based browser test runner that Polly uses internally
+now ships in `dist/`. Consumers wire up `*.browser.{ts,tsx}` files
+and run them with `polly test:browser <dir>` — no need to copy or
+reimplement the orchestrator. The underlying harness
+(`describe`/`test`/`expect`/`flush`/`cleanup`/`done`) already
+shipped via `@fairfox/polly/test/browser`; this closes the gap by
+exposing the runner too.
+
 #### Centralised quality logger
 
 Every `console` call in the quality tool now routes through a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,159 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2026-04-17
+
+### Added
+
+#### `@fairfox/polly/actions` — action-registry runtime
+
+A new subpath ships the plumbing that Lingua and Fairfox have both
+converged on independently: one document listener, one typed action
+registry, components that read signals and emit markup.
+
+```ts
+import {
+  installEventDelegation, createStore, createForm,
+  type ActionRegistry,
+} from "@fairfox/polly/actions";
+
+const teamForm = createForm({
+  name: "team",
+  initialValues: { name: "", description: "" },
+  onSubmit: async ({ values, stores }) => stores.data.createTeam(values),
+});
+
+const ACTION_REGISTRY: ActionRegistry<RootStore> = {
+  ...teamForm.actions,
+  "theme:toggle": ({ stores }) => stores.ui.toggleTheme(),
+};
+
+installEventDelegation((dispatch) => {
+  ACTION_REGISTRY[dispatch.action]?.(ctxFor(dispatch));
+});
+```
+
+Ships event delegation with a form-click guard and keyboard
+activation for non-interactive elements; typed `ActionRegistry` and
+`ActionContext`; a signal-backed overlay registry with
+`pushOverlay` / `popOverlay` / `closeTopOverlay`; a `createStore`
+base and `StoreProvider` / `useStores` context wiring; a `createForm`
+primitive that extends the store base with per-field signals, an
+aggregated values signal, open/close/submit methods, an entity
+`guard` effect (autonomous close when the subject disappears), and
+three auto-registered action handlers; an optional `createFormSet`
+for many-form apps; a global `errorState` signal with `setError` /
+`clearError` / `submitError` that routes handler failures to the
+UI; and `runAction` / `createMockStores` / `createMockElement` /
+`createMockSubmitEvent` testing helpers for DOM-less unit tests.
+
+#### `@fairfox/polly/ui` — compound UI primitives
+
+Eight primitives sit on top of the action runtime. Every element
+carries `data-polly-*` hooks for stable selectors, focus rings are
+visible on WCAG 2.4.11 terms, hit targets meet WCAG 2.5.8, focus is
+trapped inside modals and restored on close, aria attributes are
+wired automatically, `prefers-reduced-motion` zeroes every motion
+token, and overlays portal through a single `<OverlayRoot />`.
+
+```tsx
+import {
+  Layout, Modal, ActionForm, TextInput, ActionInput,
+  ConfirmDialog, Toast, OverlayRoot,
+} from "@fairfox/polly/ui";
+import "@fairfox/polly/ui/styles.css";
+import "@fairfox/polly/ui/theme.css";
+import "@fairfox/polly/ui/components.css";
+```
+
+`<Layout>` is the one primitive that owns layouting concerns (CSS
+grid via custom properties). `<Modal>` is compound (Root / Backdrop
+/ Content / Header / Title / Body / Footer / Close). `<ActionForm>`
+wraps `<form>` and wires `data-action="{form.name}:submit"` plus
+`aria-busy`. `<TextInput>` is passive and signal-friendly — pass a
+plain string for uncontrolled mode (FormData picks up the value on
+submit) or a `Signal<string>` for controlled. `<ActionInput>` is
+Fairfox's dual-mode view/edit with action dispatch on commit,
+`saveOn` picks the trigger, `renderView` opts into rich view
+rendering without adding deps. `<ConfirmDialog.Host />` exposes a
+Promise-returning `confirm()`. `<Toast.Viewport />` consumes
+`errorState` automatically.
+
+Theming splits across two stylesheets. `theme.css` carries semantic
+tokens consumers override (`--polly-surface`, `--polly-text`,
+`--polly-accent`, space / radius / motion scales, light + dark
+palettes, explicit `data-polly-theme` override, WCAG AA contrast
+in both modes). `styles.css` carries the structural and a11y rules
+that should not be overridden.
+
+#### CSS conformance checks in `@fairfox/polly/quality`
+
+Four new subcommands enforce the styling contract:
+
+```
+polly quality css          # all four
+polly quality css-quality  # hardcoded values
+polly quality css-layout   # Layout-component enforcement
+polly quality css-vars     # undefined var references
+polly quality css-unused   # dead selectors (advisory)
+```
+
+Each check exposes a library function (`checkCssQuality`,
+`checkCssLayout`, `checkCssVars`, `checkCssUnused`) for programmatic
+use. Rule disabling, token-prefix configuration, layout exempt
+paths, and dynamic-variable lists are all configurable per check.
+
+A `polly-ignore-all` marker in a file's first-line CSS comment opts
+out of `css-quality`. A `layout-ignore` CSS comment on the line or
+the preceding line opts out of `css-layout`.
+
+#### `@fairfox/polly/test/visual` — visual regression harness
+
+A new testing subpath pairs with the existing `@fairfox/polly/test/browser`
+harness and adds pixel-diff assertions via pixelmatch.
+
+```ts
+import { matchBaseline, resolveVisualPaths } from "@fairfox/polly/test/visual";
+
+const { baselinesDir, diffsDir } = resolveVisualPaths(projectRoot);
+const result = await matchBaseline(page, "modal-dark", baselinesDir, diffsDir, {
+  theme: "dark",
+  motion: "reduced",
+  selector: "[data-polly-modal-content]",
+});
+```
+
+Emulates `prefers-color-scheme` and `prefers-reduced-motion`, masks
+time-varying selectors, commits baselines under
+`tests/visual/__baselines__/`, writes diff PNGs on mismatch under
+`tests/visual/__diffs__/`. `POLLY_VISUAL_UPDATE=1` overwrites
+baselines locally; the harness refuses that env var when `CI=true`
+to prevent silently-drifted baselines from landing.
+
+#### Centralised quality logger
+
+Every `console` call in the quality tool now routes through a
+mutable `logger` singleton exported from `@fairfox/polly/quality`.
+Tests swap its methods at runtime and restore with `resetLogger()`.
+
+#### Recipe
+
+`recipes/actions-driven-app/` demonstrates the complete loop
+end-to-end: stores, forms, registry, components, $persistedState,
+and five unit tests.
+
+### Documentation
+
+- `docs/ACTIONS.md` — the action-registry pattern, three-layer
+  split, form lifecycle, error surface, migration guide.
+- `docs/UI.md` — compound components, theming contract, a11y
+  guarantees, styling hooks, per-primitive worked examples.
+- `docs/CSS.md` — the four CSS conformance checks, configuration,
+  escape hatches, programmatic use.
+- `docs/TESTING.md` — new sections on action-handler testing with
+  `runAction`, visual regression with `matchBaseline`, and the
+  quality logger mock pattern.
+
 ## [0.21.0] - 2026-04-16
 
 ### Added

--- a/biome.json
+++ b/biome.json
@@ -134,14 +134,33 @@
       "linter": {
         "rules": {
           "complexity": {
-            "noForEach": "off"
+            "noForEach": "off",
+            "noBannedTypes": "off"
           },
           "style": {
             "useForOf": "off",
             "noNonNullAssertion": "off"
           },
           "suspicious": {
-            "noExplicitAny": "off"
+            "noExplicitAny": "off",
+            "noEmptyBlockStatements": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.browser.ts", "**/*.browser.tsx"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off",
+            "noEmptyBlockStatements": "off"
+          },
+          "correctness": {
+            "noUnusedImports": "off"
           }
         }
       }

--- a/build-lib.ts
+++ b/build-lib.ts
@@ -51,6 +51,9 @@ const libResult = await Bun.build({
     "src/elysia/index.ts",
     "src/client/index.ts",
 
+    // Actions subpath (event delegation, action registry, form primitive)
+    "src/actions/index.ts",
+
     // Tool exports
     "tools/verify/src/config.ts",
     "tools/test/src/index.ts",

--- a/build-lib.ts
+++ b/build-lib.ts
@@ -54,6 +54,9 @@ const libResult = await Bun.build({
     // Actions subpath (event delegation, action registry, form primitive)
     "src/actions/index.ts",
 
+    // UI primitives subpath
+    "src/polly-ui/index.ts",
+
     // Tool exports
     "tools/verify/src/config.ts",
     "tools/test/src/index.ts",
@@ -148,6 +151,16 @@ mkdirSync(templatesDestDir, { recursive: true });
 cpSync(templatesSourceDir, templatesDestDir, { recursive: true });
 
 console.log("✅ Templates copied");
+console.log("🔨 Copying UI stylesheets...");
+
+const pollyUiSrc = join("src", "polly-ui");
+const pollyUiDest = join(DIST_DIR, "src", "polly-ui");
+mkdirSync(pollyUiDest, { recursive: true });
+for (const file of ["styles.css", "theme.css"]) {
+  await Bun.write(join(pollyUiDest, file), await Bun.file(join(pollyUiSrc, file)).text());
+}
+
+console.log("✅ UI stylesheets copied");
 console.log("🔨 Copying specs for verification tool...");
 
 // Copy MessageRouter.tla specs to dist so verify CLI can find them

--- a/build-lib.ts
+++ b/build-lib.ts
@@ -62,6 +62,7 @@ const libResult = await Bun.build({
     "tools/test/src/index.ts",
     "tools/test/src/test-utils.ts",
     "tools/test/src/browser/index.ts",
+    "tools/test/src/visual/index.ts",
     "tools/test/src/adapters/index.ts",
   ],
   outdir: DIST_DIR,
@@ -201,6 +202,8 @@ try {
       "tools/test/src/**/*",
       "tools/quality/src/index.ts",
       "tools/quality/src/no-as-casting.ts",
+      "tools/quality/src/logger.ts",
+      "tools/quality/src/css/**/*",
     ],
     exclude: [
       "src/content/**/*",

--- a/build-lib.ts
+++ b/build-lib.ts
@@ -117,6 +117,7 @@ const toolsResult = await Bun.build({
     "tools/verify/src/cli.ts",
     "tools/visualize/src/cli.ts",
     "tools/test/src/cli.ts",
+    "tools/test/src/browser/run.ts",
     "tools/quality/src/cli.ts",
     "tools/quality/src/index.ts",
     "scripts/build-extension.ts",
@@ -130,7 +131,22 @@ const toolsResult = await Bun.build({
   naming: {
     entry: "[dir]/[name].[ext]",
   },
-  external: ["ts-morph", "bun", "bun:*", "node:*"],
+  external: [
+    "ts-morph",
+    "bun",
+    "bun:*",
+    "node:*",
+    "elysia",
+    "@elysiajs/*",
+    "puppeteer",
+    "ws",
+    "@automerge/*",
+    "werift",
+    "@roamhq/wrtc",
+    "tweetnacl",
+    "pixelmatch",
+    "pngjs",
+  ],
 });
 
 if (!toolsResult.success) {

--- a/bun.lock
+++ b/bun.lock
@@ -19,35 +19,45 @@
         "@elysiajs/eden": "^1.4.8",
         "@types/bun": "^1.3.10",
         "@types/chrome": "^0.1.38",
+        "@types/pixelmatch": "^5.2.6",
+        "@types/pngjs": "^6.0.5",
         "@types/serialize-javascript": "^5.0.4",
         "@types/ws": "^8.18.1",
         "elysia": "^1.4.28",
         "fast-check": "^3.23.2",
+        "pixelmatch": "^7.1.0",
+        "pngjs": "^7.0.0",
         "puppeteer": "^24.41.0",
         "tweetnacl": "^1.0.3",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
+        "@automerge/automerge": ">= 3.2.0",
         "@automerge/automerge-repo": ">= 2.5.0",
         "@automerge/automerge-repo-network-websocket": ">= 2.5.0",
         "@automerge/automerge-repo-storage-indexeddb": ">= 2.5.0",
         "@automerge/automerge-repo-storage-nodefs": ">= 2.5.0",
         "@elysiajs/eden": ">= 1.2.0",
         "@preact/signals": "^2.5.1",
+        "@roamhq/wrtc": ">= 0.8.0",
         "elysia": ">= 1.4.0",
         "preact": "^10.28.1",
         "tweetnacl": ">= 1.0.0",
         "typescript": "^5.9.3",
+        "werift": ">= 0.19.0",
         "ws": ">= 8.0.0",
       },
       "optionalPeers": [
+        "@automerge/automerge",
         "@automerge/automerge-repo",
         "@automerge/automerge-repo-network-websocket",
         "@automerge/automerge-repo-storage-indexeddb",
         "@automerge/automerge-repo-storage-nodefs",
         "@elysiajs/eden",
+        "@roamhq/wrtc",
         "elysia",
         "tweetnacl",
+        "werift",
         "ws",
       ],
     },
@@ -153,6 +163,10 @@
     "@types/har-format": ["@types/har-format@1.2.16", "", {}, "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A=="],
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
+
+    "@types/pixelmatch": ["@types/pixelmatch@5.2.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg=="],
+
+    "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
 
     "@types/serialize-javascript": ["@types/serialize-javascript@5.0.4", "", {}, "sha512-Z2R7UKFuNWCP8eoa2o9e5rkD3hmWxx/1L0CYz0k2BZzGh0PhEVMp9kfGiqEml/0IglwNERXZ2hwNzIrSz/KHTA=="],
 
@@ -375,6 +389,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pixelmatch": ["pixelmatch@7.1.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "preact": ["preact@10.29.0", "", {}, "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="],
 

--- a/cli/polly.ts
+++ b/cli/polly.ts
@@ -16,6 +16,7 @@
  *   polly lint [--fix]               Lint your code
  *   polly format                     Format your code
  *   polly test [args]                Run tests (requires bun test)
+ *   polly test:browser [dir]         Run *.browser.{ts,tsx} in Puppeteer
  *   polly verify [args]              Run formal verification
  *   polly visualize [args]           Generate architecture diagrams
  *   polly quality [args]             Run quality conformance checks
@@ -259,6 +260,30 @@ async function test() {
 }
 
 /**
+ * Browser test command — bundles *.browser.{ts,tsx} files, serves them,
+ * opens a Puppeteer page, and collects results. Consumers use this to
+ * run tests written with @fairfox/polly/test/browser in a real browser.
+ */
+async function testBrowser() {
+  const bundledCli = `${__dirname}/../tools/test/src/browser/run.js`;
+  const monorepoCli = `${__dirname}/../tools/test/src/browser/run.ts`;
+  const browserCli = (await Bun.file(bundledCli).exists()) ? bundledCli : monorepoCli;
+
+  const proc = Bun.spawn(["bun", browserCli, ...commandArgs], {
+    cwd,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+    env: process.env,
+  });
+
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(`Browser tests failed with exit code ${exitCode}`);
+  }
+}
+
+/**
  * Check command - run all quality checks in sequence
  */
 async function check() {
@@ -321,6 +346,7 @@ Usage:
   polly lint [--fix]               Lint your code
   polly format                     Format your code
   polly test [args]                Run tests
+  polly test:browser [dir]         Run *.browser.{ts,tsx} in Puppeteer
   polly verify [args]              Run formal verification
   polly visualize [args]           Generate architecture diagrams
   polly quality [args]             Run quality conformance checks
@@ -362,6 +388,9 @@ async function main() {
         break;
       case "test":
         await test();
+        break;
+      case "test:browser":
+        await testBrowser();
         break;
       case "verify":
         await verify();

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -1,0 +1,169 @@
+# Actions
+
+One listener. One typed registry. Components read signals and emit markup.
+`@fairfox/polly/actions` ships the runtime.
+
+## When to use actions
+
+Reach for the actions layer when your components are mutating state directly
+— calling store methods in event handlers, threading callbacks through
+deeply nested props, or scattering identical event-handling logic across
+many files. Centralise the logic in one registry, let components stay
+logic-free, get typed handlers and a single testing surface in return.
+
+Do not reach for actions when state flows one way and your components are
+already thin views over signals. The pattern pays off once the handler
+surface grows past a handful.
+
+## Three layers
+
+Every actions-driven app has the same three parts.
+
+**Event delegation.** One document listener catches click, submit, change,
+input, keydown. It walks up the DOM with `closest('[data-action]')`, parses
+`data-action-*` attributes into a camelCase object, and dispatches to a
+named handler. Forms fire their action on submit only. Enter and Space
+activate non-interactive elements that carry `data-action`. Escape pops
+the topmost overlay.
+
+**Action registry.** A typed map from action name to handler. Each handler
+receives `{ stores, event, element, data }` and returns void or a Promise.
+All business logic lives here; components never mutate state directly.
+
+**Stores.** Typed bags of signals plus methods. Methods are the only
+mutation surface: actions call them; components read the signals they
+expose. The store bag is wired into Preact context via `StoreProvider`,
+reached from any component with `useStores()`.
+
+```ts
+import {
+  installEventDelegation, type ActionRegistry, type ActionContext,
+} from '@fairfox/polly/actions';
+
+const ACTION_REGISTRY: ActionRegistry<RootStore> = {
+  'theme:toggle': ({ stores }) => { stores.ui.toggleTheme(); },
+  'team:create': async ({ data, stores }) => {
+    await stores.data.createTeam({ name: data.name });
+  },
+};
+
+installEventDelegation((dispatch) => {
+  const handler = ACTION_REGISTRY[dispatch.action];
+  handler?.(ctxFor(dispatch, stores));
+});
+```
+
+Components emit:
+
+```tsx
+<button data-action="theme:toggle">Toggle theme</button>
+<button data-action="team:create" data-action-name="Alpha">New team</button>
+```
+
+## Forms
+
+`createForm` is the specialisation of `createStore` most apps reach for.
+Each form exposes per-field signals, an aggregated values signal, methods
+(`open`, `close`, `submit`), and three auto-registered action handlers
+(`{name}:open`, `{name}:close`, `{name}:submit`). Spread `.actions` into
+the registry and the form responds to `<button data-action="team:open">`
+and `<form data-action="team:submit">` out of the box.
+
+```ts
+const teamForm = createForm<TeamValues, RootStore>({
+  name: 'team',
+  initialValues: { name: '', description: '' },
+  guard: ({ stores }) =>
+    stores.data.teams.value.some(t => t.id === stores.view.modalEntityId),
+  onOpen: ({ data, stores }) => {
+    const id = data.entityId;
+    const existing = stores.data.teams.value.find(t => t.id === id);
+    return existing ? { name: existing.name } : {};
+  },
+  onSubmit: async ({ values, stores }) => {
+    await stores.data.createTeam(values);
+  },
+});
+
+const ACTION_REGISTRY: ActionRegistry<RootStore> = {
+  ...teamForm.actions,
+  'theme:toggle': ({ stores }) => stores.ui.toggleTheme(),
+};
+```
+
+`guard` runs as an internal effect: if it returns false while the form is
+open, the form closes automatically. Useful for "entity deleted
+mid-edit" — a user editing a team whose subject disappears should not
+stay on a dead form.
+
+`createFormSet([formA, formB])` composes many forms: merged `.actions`,
+a single `openForm` signal ("which form is open, if any"), and
+`closeAll()` for cleanup. Apps with dozens of forms avoid repeating
+the spread for every registry.
+
+## Error surface
+
+Actions that throw, and any handler that wants to surface a user-visible
+message, route through the global `errorState` signal via `submitError`.
+The Toast component in `@fairfox/polly/ui` consumes that signal
+automatically; apps that want bespoke error rendering read it directly.
+
+```ts
+import { submitError } from '@fairfox/polly/actions';
+
+const ACTION_REGISTRY: ActionRegistry<RootStore> = {
+  'team:delete': async ({ data, stores }) => {
+    try {
+      await stores.data.deleteTeam(data.teamId);
+    } catch (err) {
+      submitError('team:delete', err);
+    }
+  },
+};
+```
+
+## Testing
+
+`runAction` invokes a handler in isolation. Construct a mock stores bag
+with `createMockStores`, build a fake element with `createMockElement`
+when a handler reads from `data-action-*` attributes, and wrap it all
+with `runAction`. No jsdom, no browser harness, no document listener.
+
+```ts
+import { runAction } from '@fairfox/polly/actions';
+
+test('team:create writes through to the store', async () => {
+  const stores = createMockStores({
+    data: { createTeam: mock() },
+  });
+  await runAction(ACTION_REGISTRY, 'team:create', {
+    stores,
+    data: { name: 'Alpha' },
+  });
+  expect(stores.data.createTeam).toHaveBeenCalledWith({ name: 'Alpha' });
+});
+```
+
+For full-DOM coverage — focus trap, portal parentage, scroll lock — use
+the Puppeteer harness at `@fairfox/polly/test/browser`. The unit-level
+helpers here are for handler logic.
+
+## Migrating an ad-hoc app
+
+If an app has scattered `onClick` handlers mutating module-scope
+signals, migrate one feature at a time. Pick a feature. Replace the
+inline handler with a `data-action` attribute. Move the logic into the
+registry. Hoist the feature's state from component scope to a store.
+Delete the callback prop. Repeat.
+
+The plumbing can coexist with bespoke callbacks during migration — the
+event delegation only fires when it sees `data-action`; other clicks
+flow through Preact as before. A gradual migration stays green at
+every step.
+
+## API reference
+
+See the source at `src/actions/` for exact signatures; every export is
+documented by a module-level docstring. The subpath is
+`@fairfox/polly/actions`, and the TypeScript types resolve through the
+usual editor tooling.

--- a/docs/CSS.md
+++ b/docs/CSS.md
@@ -1,0 +1,123 @@
+# CSS conformance
+
+`polly quality` ships four CSS checks that enforce the styling contract
+behind `@fairfox/polly/ui`. Apps opt in by pointing the tool at their
+own CSS modules; Polly eats its own dog food.
+
+```
+polly quality                # all checks (TS + CSS)
+polly quality css            # just the CSS family
+polly quality css-quality    # hardcoded values
+polly quality css-layout     # <Layout> enforcement
+polly quality css-vars       # undefined variable references
+polly quality css-unused     # dead selectors (advisory)
+```
+
+## css-quality
+
+Rejects values that have a semantic token equivalent. Hardcoded hex
+colours, rgba literals, rem units, numeric font-weights, magic z-indexes,
+hardcoded border-radius / border-width / box-shadow, inline transitions,
+and `!important` all fail.
+
+Every rejected line carries a suggestion pointing at the right token
+family. Rules are individually disableable:
+
+```ts
+import { checkCssQuality } from '@fairfox/polly/quality';
+
+await checkCssQuality({
+  rootDir: process.cwd(),
+  disableRules: ['no-rem-units'],
+});
+```
+
+A file can opt out entirely with a `polly-ignore-all` marker in a CSS
+comment on its first line — for imported third-party CSS or other
+exceptional cases.
+
+## css-layout
+
+Forbids `display: flex` and `display: grid` outside the `<Layout>`
+primitive. Apps that use this rule get two things: greppable layout
+decisions, and the guarantee that all layout in the app flows through
+one generalised component.
+
+Escape hatches for legitimate exceptions (Modal's own positioning,
+for example, uses `display: grid` to center its backdrop):
+
+```css
+.special {
+  display: grid; /* layout-ignore */
+  grid-template-columns: 1fr 1fr;
+}
+```
+
+The suppression comment may be on the violating line or the preceding
+one. Consumer configuration can extend the exempt paths:
+
+```ts
+await checkCssLayout({
+  rootDir: process.cwd(),
+  layoutExemptPaths: ['Layout.module.css', 'MyStack.module.css'],
+});
+```
+
+## css-vars
+
+Every `var(--name)` reference in `.css`, `.ts`, or `.tsx` files must
+resolve to a definition in some `.css` file under the scan root.
+Catches typos and references to removed tokens.
+
+Variables that are set at runtime via inline styles can be listed so
+the check treats them as defined:
+
+```ts
+await checkCssVars({
+  rootDir: process.cwd(),
+  dynamicVars: ['--l-cols', '--l-rows', '--max-lines'],
+});
+```
+
+## css-unused
+
+Advisory. Finds classes and locally-defined custom properties in
+`.module.css` files that appear to have no reference. The check is
+textual and cannot see through dynamic lookups (`styles[key]` with a
+computed key), so treat the output as a hint rather than a hard
+failure.
+
+## Configuration
+
+Each check takes a common shape:
+
+```ts
+{
+  rootDir: string;       // scan target
+  skipDirs?: string[];   // directory names to skip during recursion
+  // plus check-specific options
+}
+```
+
+Defaults skip `node_modules`, `dist`, `.git`, `.bun`, `dist-test`,
+`build`, and `coverage`.
+
+## Programmatic use
+
+Each check is available as a library function for custom pipelines:
+
+```ts
+import { checkCssQuality, checkCssLayout } from '@fairfox/polly/quality';
+
+const results = await Promise.all([
+  checkCssQuality({ rootDir }),
+  checkCssLayout({ rootDir }),
+]);
+for (const r of results) r.print();
+if (results.some((r) => r.violations.length > 0)) process.exit(1);
+```
+
+The output sink goes through the quality tool's `logger` singleton,
+which tests replace at runtime by assigning to `logger.log`,
+`logger.error`, etc. — call `resetLogger()` to restore the defaults
+after a test. See `tests/unit/quality/logger.test.ts` for the pattern.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -767,3 +767,95 @@ Current test coverage: **all tests passing**
 - ✅ Full type safety with TypeScript strict mode
 
 E2E tests with Playwright are run separately for browser-based scenarios.
+
+---
+
+## Action handler tests
+
+Actions are plain functions taking a typed context. Test them in
+isolation with `runAction` from `@fairfox/polly/actions`:
+
+```ts
+import {
+  createMockElement, createMockStores, runAction,
+  type ActionRegistry,
+} from '@fairfox/polly/actions';
+
+test('team:create writes to the store', async () => {
+  const stores = createMockStores({
+    data: { createTeam: mock() },
+  });
+  await runAction(ACTION_REGISTRY, 'team:create', {
+    stores,
+    data: { name: 'Alpha' },
+  });
+  expect(stores.data.createTeam).toHaveBeenCalledWith({ name: 'Alpha' });
+});
+```
+
+No jsdom, no event dispatch, no document listener — the runner
+builds the context and calls the handler directly. For full-DOM
+coverage use the browser harness at `@fairfox/polly/test/browser`.
+
+---
+
+## Visual regression
+
+`@fairfox/polly/test/visual` adds screenshot-based regression testing
+on top of the Puppeteer browser harness. Tests render a primitive,
+call `matchBaseline(page, name, baselinesDir, diffsDir, options)`, and
+the harness diffs the result against a committed PNG.
+
+Baselines live at `tests/visual/__baselines__/` and are committed to
+the repo. CI fails on any mismatch above the configured tolerance
+(default 0.1% of pixels). Regenerate baselines locally:
+
+```sh
+POLLY_VISUAL_UPDATE=1 bun tools/test/src/browser/run.ts tests/visual
+```
+
+The harness refuses `POLLY_VISUAL_UPDATE=1` when `CI=true` so a
+silently drifted baseline cannot enter the repo through a green CI.
+
+Emulation options cover the two axes that change visual output:
+
+```ts
+await matchBaseline(page, 'modal-dark', baselines, diffs, {
+  theme: 'dark',
+  motion: 'reduced',
+  selector: '[data-polly-modal-content]',
+  maskSelectors: ['[data-testid="timestamp"]'],
+});
+```
+
+`theme` flips `prefers-color-scheme`. `motion` flips
+`prefers-reduced-motion` between `full` and `reduced`. `selector`
+scopes capture to one element. `maskSelectors` hides time-varying
+content (dates, random IDs) before the shot.
+
+---
+
+## Quality logger in tests
+
+Every `console.log` and `console.error` in the quality tool goes
+through a singleton `logger` at `@fairfox/polly/quality`. Tests swap
+its methods to capture output, then call `resetLogger()` to restore
+the defaults:
+
+```ts
+import { afterEach, beforeEach, test } from 'bun:test';
+import { logger, resetLogger } from '@fairfox/polly/quality';
+
+let captured: string[];
+
+beforeEach(() => {
+  captured = [];
+  logger.log = (m) => captured.push(m);
+  logger.error = (m) => captured.push(`[err] ${m}`);
+});
+
+afterEach(() => resetLogger());
+```
+
+This avoids wrapping `console.log` globally and keeps the output
+side-effect scoped to the test that cares about it.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1,0 +1,237 @@
+# UI primitives
+
+`@fairfox/polly/ui` provides eight compound components that sit on top of
+the action-registry runtime. The split of responsibility is deliberate:
+Polly owns accessibility and structure; consumers own visual values.
+
+## Import
+
+```ts
+import {
+  Layout, Modal, ActionForm, TextInput, ActionInput,
+  ConfirmDialog, Toast, OverlayRoot,
+} from '@fairfox/polly/ui';
+
+import '@fairfox/polly/ui/styles.css';      // structural + a11y — keep it
+import '@fairfox/polly/ui/theme.css';       // default tokens — override or replace
+import '@fairfox/polly/ui/components.css';  // per-component styles — keep it
+```
+
+## Theming contract
+
+Two stylesheets exist because two kinds of CSS exist in this library.
+
+`styles.css` carries the rules that must not be overridden. Focus ring,
+minimum hit targets, scroll lock, overlay stacking, and reduced-motion
+handling all live here. Apps that want different visuals override
+`theme.css` or redefine individual variables; they should not touch
+`styles.css`. If you find yourself wanting to override something in
+`styles.css`, that is a signal to file an issue rather than work around
+the cascade.
+
+`theme.css` carries semantic tokens. Every surface, border, text colour,
+accent, focus ring, space, radius, motion duration, font stack, and
+typography size is a `--polly-*` variable. Both the light palette
+(default) and the dark palette (under `prefers-color-scheme: dark`) pass
+WCAG AA contrast against their surface. An ancestor element with
+`data-polly-theme="dark"` or `data-polly-theme="light"` forces that mode
+regardless of system preference.
+
+To re-theme, define the variables in a higher cascade layer or in your
+own stylesheet loaded after `theme.css`:
+
+```css
+:root {
+  --polly-accent: #d64045;
+  --polly-accent-contrast: #fff;
+  --polly-radius-md: 2px;
+  --polly-font-sans: "Inter", system-ui, sans-serif;
+}
+```
+
+## The primitives
+
+### Layout
+
+The only component that owns layouting concerns. CSS Grid under the hood,
+configured through props that map to CSS custom properties. The
+`polly quality css-layout` check enforces "no `display: flex|grid`
+outside Layout" across app CSS; use `/* layout-ignore */` to suppress
+one-off cases.
+
+```tsx
+<Layout columns="1fr 2fr" gap="var(--polly-space-lg)" padding="var(--polly-space-md)">
+  <aside>nav</aside>
+  <main>content</main>
+</Layout>
+```
+
+Props of interest: `rows`, `columns`, `gap`, `padding`, `stackOnMobile`
+(collapse to a single column at ≤640px), `justifyItems`, `alignItems`,
+`contents` (display: contents for transparent nesting), `subgrid`.
+
+### Modal
+
+Compound dialog with focus trap, Escape handling, portal into
+`OverlayRoot`, scroll lock, stacking. Root takes a signal for open state.
+Focus moves inside on open and returns to the opener on close. Tab and
+Shift+Tab are trapped. Escape pops the topmost overlay through the
+registry.
+
+```tsx
+<Modal.Root when={form.isOpen} onClose={() => form.close()}>
+  <Modal.Backdrop />
+  <Modal.Content>
+    <Modal.Header>
+      <Modal.Title>Edit team</Modal.Title>
+      <Modal.Close>Close</Modal.Close>
+    </Modal.Header>
+    <Modal.Body>…</Modal.Body>
+    <Modal.Footer>…</Modal.Footer>
+  </Modal.Content>
+</Modal.Root>
+```
+
+`Modal.Close` accepts an optional `action` prop to dispatch a named
+action instead of calling the onClose callback. Useful when the close
+semantics need to live in the registry.
+
+### ActionForm
+
+Wraps `<form>` and sets `data-action="{form.name}:submit"` so the event
+delegation reaches the form's auto-registered submit handler. Mirrors
+`isSubmitting` onto `aria-busy` so consumer styling can respond without
+extra wiring.
+
+```tsx
+<ActionForm form={teamForm}>
+  <TextInput name="name" required />
+  <button type="submit">Save</button>
+</ActionForm>
+```
+
+### TextInput
+
+Passive, token-styled native `<input>` or `<textarea>` (via `variant`).
+Signal-backed: pass a plain string for uncontrolled (FormData picks up
+the value on submit) or a `Signal<string>` for controlled. `invalid`
+flips `aria-invalid` and `data-state="invalid"` for styling hooks.
+
+### ActionInput
+
+Dual-mode view/edit with action dispatch on commit. View mode renders
+the current value as text; click, Enter, or Space enters edit mode;
+`saveOn` picks the commit trigger (`blur`, `enter`, `cmd-enter`,
+`explicit`). Commit fires the configured action with a synthetic hidden
+element carrying `data-action-value`, so the existing delegation picks
+it up. View and edit modes share padding, border width, font, and
+line-height so toggling between them causes zero layout shift.
+
+```tsx
+<ActionInput
+  value={todo.title}
+  action="todo:rename"
+  actionData={{ todoId: todo.id }}
+  saveOn="enter"
+/>
+```
+
+Markdown or rich-view rendering is opt-in via the `renderView` prop to
+keep the core dep-light:
+
+```tsx
+<ActionInput
+  value={note.body}
+  action="note:update"
+  variant="multi"
+  renderView={(value) => <MarkdownPreview source={value} />}
+/>
+```
+
+### ConfirmDialog
+
+Promise-returning confirmation. Mount `<ConfirmDialog.Host />` once near
+the app root; call `confirm({ title, body, danger })` from an action
+handler to prompt the user. Resolves `true` on OK, `false` on Cancel,
+Escape, or backdrop click.
+
+```tsx
+import { ConfirmDialog, confirm } from '@fairfox/polly/ui';
+
+const ACTION_REGISTRY = {
+  'team:delete': async ({ data, stores }) => {
+    const ok = await confirm({
+      title: 'Delete team?',
+      body: 'This cannot be undone.',
+      danger: true,
+    });
+    if (!ok) return;
+    await stores.data.deleteTeam(data.teamId);
+  },
+};
+
+function App() {
+  return (
+    <>
+      {/* your app */}
+      <OverlayRoot />
+      <ConfirmDialog.Host />
+    </>
+  );
+}
+```
+
+### Toast
+
+Consumes the global `errorState` signal automatically. Mount
+`<Toast.Viewport />` once near the app root; `submitError` and `setError`
+calls from anywhere surface as toasts. Auto-dismisses after
+`autoDismissMs` (default 5s) with pause-on-hover. Severity maps to
+`aria-live="polite"` for warning/info and `"assertive"` for errors.
+
+### OverlayRoot
+
+Portal target plus scroll-lock management. Mount once as late as
+practical in your app tree; every overlay (Modal, ConfirmDialog, Toast)
+portals into it. The `hasOpenOverlay()` function from
+`@fairfox/polly/actions` is what drives the scroll lock, so any
+overlay-like component registered with the overlay registry will behave
+consistently.
+
+## Accessibility guarantees
+
+- Every interactive primitive has a visible focus ring whose colour
+  reads from `--polly-focus-ring` (consumer may tune colour; shape and
+  offset are fixed for WCAG 2.4.11 compliance).
+- Every interactive element has a 44×44 minimum hit target (WCAG 2.5.8).
+  Opt out via `data-polly-hit-target="none"` for dense toolbars where
+  the size isn't appropriate.
+- Modals trap focus inside and restore it on close.
+- Toasts announce through `aria-live`.
+- Reduced-motion honours `prefers-reduced-motion: reduce` by zeroing
+  every `--polly-motion-*` token.
+- Dialogs set `role="dialog"`, `aria-modal="true"`, and either
+  `aria-labelledby` (from `Modal.Title`) or an explicit `aria-label`.
+
+## Styling hooks
+
+Every internal element carries a `data-polly-*` attribute for stable
+selectors:
+
+| Hook | On |
+|------|----|
+| `[data-polly-ui]` | Every primitive's outer element |
+| `[data-polly-interactive]` | Elements with hit-target enforcement |
+| `[data-polly-overlay-root]` | The portal target |
+| `[data-polly-modal-content]` | Modal outer container |
+| `[data-polly-modal-surface]` | Modal visible surface |
+| `[data-polly-modal-backdrop]` | Modal backdrop |
+| `[data-polly-action-form]` | ActionForm `<form>` element |
+| `[data-polly-input]` | TextInput native input |
+| `[data-polly-action-input]` | ActionInput outer element |
+| `[data-polly-toast-viewport]` | Toast portal |
+| `[data-polly-toast-item]` | Individual toast |
+
+Style overrides should hook onto these attributes rather than the
+generated CSS-module class names; the module names are hashed at build
+time and will change.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
       "import": "./dist/tools/test/src/browser/index.js",
       "types": "./dist/tools/test/src/browser/index.d.ts"
     },
+    "./test/visual": {
+      "import": "./dist/tools/test/src/visual/index.js",
+      "types": "./dist/tools/test/src/visual/index.d.ts"
+    },
     "./peer": {
       "import": "./dist/src/peer.js",
       "types": "./dist/src/peer.d.ts"
@@ -134,10 +138,14 @@
     "@elysiajs/eden": "^1.4.8",
     "@types/bun": "^1.3.10",
     "@types/chrome": "^0.1.38",
+    "@types/pixelmatch": "^5.2.6",
+    "@types/pngjs": "^6.0.5",
     "@types/serialize-javascript": "^5.0.4",
     "@types/ws": "^8.18.1",
     "elysia": "^1.4.28",
     "fast-check": "^3.23.2",
+    "pixelmatch": "^7.1.0",
+    "pngjs": "^7.0.0",
     "puppeteer": "^24.41.0",
     "tweetnacl": "^1.0.3",
     "typescript": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
     "./quality": {
       "import": "./dist/tools/quality/src/index.js",
       "types": "./dist/tools/quality/src/index.d.ts"
+    },
+    "./actions": {
+      "import": "./dist/src/actions/index.js",
+      "types": "./dist/src/actions/index.d.ts"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -89,7 +89,14 @@
     "./actions": {
       "import": "./dist/src/actions/index.js",
       "types": "./dist/src/actions/index.d.ts"
-    }
+    },
+    "./ui": {
+      "import": "./dist/src/polly-ui/index.js",
+      "types": "./dist/src/polly-ui/index.d.ts"
+    },
+    "./ui/styles.css": "./dist/src/polly-ui/styles.css",
+    "./ui/theme.css": "./dist/src/polly-ui/theme.css",
+    "./ui/components.css": "./dist/src/polly-ui/index.css"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,23 @@
+# Recipes
+
+A recipe answers a goal — *"I want to do X"* — with **one** opinionated,
+end-to-end solution. Examples show APIs; recipes show "here's the one
+correct way to achieve this".
+
+| | Examples | Recipes |
+|---|---|---|
+| Question answered | "How does this API work?" | "I want to do X — what should I build?" |
+| Voice | Descriptive | Prescriptive |
+| Count per goal | Many approaches OK | One blessed approach |
+| Completeness | Can be a fragment | Must be end-to-end deployable |
+| Invites variation | Yes — study and adapt | No — copy and ship |
+
+## Recipes
+
+- [actions-driven-app](actions-driven-app/) — "I want a Polly app where
+  all state mutation goes through typed action handlers." Demonstrates
+  `createStore`, `createForm`, `<ActionForm>`, `<TextInput>`,
+  `<ActionInput>`, `<Modal>`, `<Toast>`, and `$persistedState` end to end.
+
+Further recipes covering specific deployment shapes (Cloudflare Pages +
+Worker signalling, Raspberry Pi mesh peer) are tracked in issue #49.

--- a/recipes/actions-driven-app/README.md
+++ b/recipes/actions-driven-app/README.md
@@ -1,0 +1,64 @@
+# actions-driven-app
+
+> I want a Polly app where every state mutation flows through typed
+> action handlers and components stay logic-free.
+
+A minimal todo list demonstrating the full `@fairfox/polly/actions` +
+`@fairfox/polly/ui` loop end to end.
+
+## What's in it
+
+- **Stores** (`src/stores.ts`) — one store for the todo list (backed by
+  `$persistedState`), one for view state. Methods are the only
+  mutation surface.
+- **Forms** (`src/forms.ts`) — one `createForm` for the create-todo
+  modal, with a validator that rejects blank titles.
+- **Action registry** (`src/actions.ts`) — five entries (plus the three
+  auto-registered from the form). All business logic lives here.
+- **Components** (`src/App.tsx`) — Layout for structure, Modal for the
+  create dialog, ActionForm + TextInput for the form, ActionInput for
+  inline-edit of todo titles, Toast for errors. Every component reads
+  signals and emits `data-action` markup. No callbacks.
+- **Entry point** (`src/main.tsx`) — stores bag, form binding,
+  `installEventDelegation`, `StoreProvider`, `render`.
+
+## The loop
+
+Every click-to-change-to-render flows:
+
+1. User clicks a button with `data-action="todo:toggle"`
+2. The document listener picks it up, parses `data-action-*` attrs
+3. The matching entry in `ACTION_REGISTRY` runs, calls
+   `stores.todos.toggle(id)`
+4. The store's `todos` signal changes
+5. Every component reading `todos.value` re-renders
+
+## Running locally
+
+```sh
+bun install
+bun test tests
+bunx tsc --noEmit
+```
+
+The recipe ships without a bundler wired up — adopt any (Bun, Vite,
+Rollup) and point it at `src/main.tsx`. The structural CSS, theme
+tokens, and per-component styles are three separate imports in
+`main.tsx` so consumers can opt out of the defaults.
+
+## What it's for
+
+Copy this folder into a new app; the skeleton is ready to grow. Add
+stores to `makeRootStore()`, add forms next to their features, add
+action handlers for any new interaction, render through the compound
+primitives. The three-layer split (delegation, registry, stores)
+stays intact no matter how many features you add.
+
+## What it deliberately doesn't cover
+
+- **Deployment shape** — follow-up recipes handle Cloudflare Pages,
+  Raspberry Pi mesh peers, and other goal-shaped deploy targets.
+- **Routing** — the action registry dispatches events, not routes.
+  Pick any router; the pattern doesn't know about URLs.
+- **Domain-specific styling** — the default theme is sane, not
+  branded. Override `--polly-*` tokens for the look of your app.

--- a/recipes/actions-driven-app/bun.lock
+++ b/recipes/actions-driven-app/bun.lock
@@ -1,0 +1,37 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "recipe-actions-driven-app",
+      "dependencies": {
+        "@fairfox/polly": "link:../..",
+        "@preact/signals": "^2.5.1",
+        "preact": "^10.28.1",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.5",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@fairfox/polly": ["@fairfox/polly@link:../..", { "bin": { "polly": "./dist/cli/polly.js" } }],
+
+    "@preact/signals": ["@preact/signals@2.9.0", "", { "dependencies": { "@preact/signals-core": "^1.14.0" }, "peerDependencies": { "preact": ">= 10.25.0 || >=11.0.0-0" } }, "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug=="],
+
+    "@preact/signals-core": ["@preact/signals-core@1.14.1", "", {}, "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng=="],
+
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/recipes/actions-driven-app/package.json
+++ b/recipes/actions-driven-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "recipe-actions-driven-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test tests"
+  },
+  "dependencies": {
+    "@fairfox/polly": "link:../..",
+    "preact": "^10.28.1",
+    "@preact/signals": "^2.5.1"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "typescript": "^5.9.3"
+  }
+}

--- a/recipes/actions-driven-app/src/App.tsx
+++ b/recipes/actions-driven-app/src/App.tsx
@@ -6,6 +6,7 @@
  * action registry in `actions.ts`.
  */
 
+import { useStores } from "@fairfox/polly/actions";
 import {
   ActionForm,
   ActionInput,
@@ -15,7 +16,6 @@ import {
   TextInput,
   Toast,
 } from "@fairfox/polly/ui";
-import { useStores } from "@fairfox/polly/actions";
 import { createTodoForm } from "./forms.ts";
 import type { RootStore } from "./stores.ts";
 
@@ -33,12 +33,7 @@ export function App() {
       >
         <Layout as="header" columns="1fr auto" alignItems="center">
           <h1>Todos</h1>
-          <button
-            type="button"
-            data-polly-ui
-            data-polly-interactive
-            data-action="theme:toggle"
-          >
+          <button type="button" data-polly-ui data-polly-interactive data-action="theme:toggle">
             {theme === "dark" ? "Light" : "Dark"}
           </button>
         </Layout>
@@ -82,12 +77,7 @@ export function App() {
         </Layout>
 
         <Layout as="footer">
-          <button
-            type="button"
-            data-polly-ui
-            data-polly-interactive
-            data-action="todo:create:open"
-          >
+          <button type="button" data-polly-ui data-polly-interactive data-action="todo:create:open">
             New todo
           </button>
         </Layout>
@@ -96,10 +86,7 @@ export function App() {
       <OverlayRoot />
       <Toast.Viewport />
 
-      <Modal.Root
-        when={createTodoForm.isOpen}
-        onClose={() => createTodoForm.close()}
-      >
+      <Modal.Root when={createTodoForm.isOpen} onClose={() => createTodoForm.close()}>
         <Modal.Backdrop />
         <Modal.Content>
           <Modal.Header>
@@ -109,6 +96,7 @@ export function App() {
           <Modal.Body>
             <ActionForm form={createTodoForm}>
               <Layout gap="var(--polly-space-md)">
+                {/* biome-ignore lint/a11y/noLabelWithoutControl: label wraps the nested TextInput component; biome cannot see through component composition. */}
                 <label>
                   Title
                   <TextInput name="title" required autoFocus />

--- a/recipes/actions-driven-app/src/App.tsx
+++ b/recipes/actions-driven-app/src/App.tsx
@@ -1,0 +1,138 @@
+/**
+ * App root.
+ *
+ * Components are logic-free: they read signals and emit markup with
+ * data-action attributes. Every state mutation happens through the
+ * action registry in `actions.ts`.
+ */
+
+import {
+  ActionForm,
+  ActionInput,
+  Layout,
+  Modal,
+  OverlayRoot,
+  TextInput,
+  Toast,
+} from "@fairfox/polly/ui";
+import { useStores } from "@fairfox/polly/actions";
+import { createTodoForm } from "./forms.ts";
+import type { RootStore } from "./stores.ts";
+
+export function App() {
+  const stores = useStores<RootStore>();
+  const theme = stores.view.theme.value;
+
+  return (
+    <div data-polly-theme={theme}>
+      <Layout
+        padding="var(--polly-space-lg)"
+        gap="var(--polly-space-md)"
+        rows="auto 1fr auto"
+        minHeight="100vh"
+      >
+        <Layout as="header" columns="1fr auto" alignItems="center">
+          <h1>Todos</h1>
+          <button
+            type="button"
+            data-polly-ui
+            data-polly-interactive
+            data-action="theme:toggle"
+          >
+            {theme === "dark" ? "Light" : "Dark"}
+          </button>
+        </Layout>
+
+        <Layout as="main" gap="var(--polly-space-sm)">
+          <p>{stores.todos.remaining.value} remaining</p>
+          <ul>
+            {stores.todos.todos.value.map((todo) => (
+              <Layout
+                as="li"
+                key={todo.id}
+                columns="auto 1fr auto"
+                gap="var(--polly-space-sm)"
+                alignItems="center"
+              >
+                <input
+                  type="checkbox"
+                  checked={todo.done}
+                  data-action="todo:toggle"
+                  data-action-todo-id={todo.id}
+                />
+                <ActionInput
+                  value={todo.title}
+                  action="todo:rename"
+                  actionData={{ todoId: todo.id }}
+                  saveOn="enter"
+                  ariaLabel="Rename todo"
+                />
+                <button
+                  type="button"
+                  data-polly-ui
+                  data-polly-interactive
+                  data-action="todo:remove"
+                  data-action-todo-id={todo.id}
+                >
+                  Remove
+                </button>
+              </Layout>
+            ))}
+          </ul>
+        </Layout>
+
+        <Layout as="footer">
+          <button
+            type="button"
+            data-polly-ui
+            data-polly-interactive
+            data-action="todo:create:open"
+          >
+            New todo
+          </button>
+        </Layout>
+      </Layout>
+
+      <OverlayRoot />
+      <Toast.Viewport />
+
+      <Modal.Root
+        when={createTodoForm.isOpen}
+        onClose={() => createTodoForm.close()}
+      >
+        <Modal.Backdrop />
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Title>New todo</Modal.Title>
+            <Modal.Close>Close</Modal.Close>
+          </Modal.Header>
+          <Modal.Body>
+            <ActionForm form={createTodoForm}>
+              <Layout gap="var(--polly-space-md)">
+                <label>
+                  Title
+                  <TextInput name="title" required autoFocus />
+                </label>
+                {createTodoForm.errors.value.title ? (
+                  <p role="alert">{createTodoForm.errors.value.title}</p>
+                ) : null}
+                <Layout columns="1fr auto auto" gap="var(--polly-space-sm)">
+                  <span />
+                  <Modal.Close>Cancel</Modal.Close>
+                  <button
+                    type="submit"
+                    data-polly-ui
+                    data-polly-interactive
+                    disabled={createTodoForm.isSubmitting.value}
+                  >
+                    Save
+                  </button>
+                </Layout>
+              </Layout>
+            </ActionForm>
+          </Modal.Body>
+        </Modal.Content>
+      </Modal.Root>
+    </div>
+  );
+}

--- a/recipes/actions-driven-app/src/actions.ts
+++ b/recipes/actions-driven-app/src/actions.ts
@@ -1,0 +1,44 @@
+/**
+ * Action registry.
+ *
+ * Every state-mutating interaction flows through here. Components emit
+ * `data-action` markup; the event delegation runtime dispatches to the
+ * handler by name. Business logic for todos, view state, and the form
+ * all live together — no callbacks threaded through components.
+ */
+
+import type { ActionRegistry } from "@fairfox/polly/actions";
+import { submitError } from "@fairfox/polly/actions";
+import { createTodoForm } from "./forms.ts";
+import type { RootStore } from "./stores.ts";
+
+export const ACTION_REGISTRY: ActionRegistry<RootStore> = {
+  ...createTodoForm.actions,
+
+  "todo:toggle": ({ data, stores }) => {
+    const id = data["todoId"];
+    if (!id) return;
+    stores.todos.toggle(id);
+  },
+
+  "todo:remove": ({ data, stores }) => {
+    const id = data["todoId"];
+    if (!id) return;
+    stores.todos.remove(id);
+  },
+
+  "todo:rename": ({ data, stores }) => {
+    const id = data["todoId"];
+    const title = data["value"];
+    if (!id || typeof title !== "string") return;
+    if (title.trim() === "") {
+      submitError("todo:rename", new Error("Title cannot be empty"));
+      return;
+    }
+    stores.todos.rename(id, title.trim());
+  },
+
+  "theme:toggle": ({ stores }) => {
+    stores.view.toggleTheme();
+  },
+};

--- a/recipes/actions-driven-app/src/forms.ts
+++ b/recipes/actions-driven-app/src/forms.ts
@@ -1,0 +1,21 @@
+/**
+ * Forms live next to their features.
+ *
+ * The create form lives here because it has no entity backing. If the
+ * app grew, an edit form with a guard and onOpen override would live
+ * alongside it — one createForm call per form.
+ */
+
+import { createForm } from "@fairfox/polly/actions";
+import type { RootStore } from "./stores.ts";
+
+export type CreateTodoValues = { title: string };
+
+export const createTodoForm = createForm<CreateTodoValues, RootStore>({
+  name: "todo:create",
+  initialValues: { title: "" },
+  validate: (v) => (v.title.trim() === "" ? { title: "Title required" } : null),
+  onSubmit: async ({ values, stores }) => {
+    stores.todos.add(values.title);
+  },
+});

--- a/recipes/actions-driven-app/src/main.tsx
+++ b/recipes/actions-driven-app/src/main.tsx
@@ -5,17 +5,13 @@
  * delegation, registers the StoreProvider, and mounts.
  */
 
-import {
-  installEventDelegation,
-  StoreProvider,
-  submitError,
-} from "@fairfox/polly/actions";
+import { installEventDelegation, StoreProvider, submitError } from "@fairfox/polly/actions";
 import "@fairfox/polly/ui/styles.css";
 import "@fairfox/polly/ui/theme.css";
 import "@fairfox/polly/ui/components.css";
 import { render } from "preact";
-import { ACTION_REGISTRY } from "./actions.ts";
 import { App } from "./App.tsx";
+import { ACTION_REGISTRY } from "./actions.ts";
 import { createTodoForm } from "./forms.ts";
 import { makeRootStore } from "./stores.ts";
 
@@ -43,5 +39,5 @@ render(
   <StoreProvider stores={stores}>
     <App />
   </StoreProvider>,
-  root,
+  root
 );

--- a/recipes/actions-driven-app/src/main.tsx
+++ b/recipes/actions-driven-app/src/main.tsx
@@ -1,0 +1,47 @@
+/**
+ * App entry point.
+ *
+ * Wires up the stores bag, late-binds forms, installs the event
+ * delegation, registers the StoreProvider, and mounts.
+ */
+
+import {
+  installEventDelegation,
+  StoreProvider,
+  submitError,
+} from "@fairfox/polly/actions";
+import "@fairfox/polly/ui/styles.css";
+import "@fairfox/polly/ui/theme.css";
+import "@fairfox/polly/ui/components.css";
+import { render } from "preact";
+import { ACTION_REGISTRY } from "./actions.ts";
+import { App } from "./App.tsx";
+import { createTodoForm } from "./forms.ts";
+import { makeRootStore } from "./stores.ts";
+
+const stores = makeRootStore();
+createTodoForm.bindStores(() => stores);
+
+installEventDelegation(async (dispatch) => {
+  const handler = ACTION_REGISTRY[dispatch.action];
+  if (!handler) return;
+  try {
+    await handler({
+      stores,
+      event: dispatch.event,
+      element: dispatch.element,
+      data: dispatch.data,
+    });
+  } catch (err) {
+    submitError(dispatch.action, err);
+  }
+});
+
+const root = document.getElementById("app");
+if (!root) throw new Error("missing #app mount point");
+render(
+  <StoreProvider stores={stores}>
+    <App />
+  </StoreProvider>,
+  root,
+);

--- a/recipes/actions-driven-app/src/stores.ts
+++ b/recipes/actions-driven-app/src/stores.ts
@@ -6,8 +6,8 @@
  * read signals and dispatch actions.
  */
 
-import { $persistedState } from "@fairfox/polly/state";
 import { createStore } from "@fairfox/polly/actions";
+import { $persistedState } from "@fairfox/polly/state";
 import { computed, signal } from "@preact/signals";
 
 export type Todo = {
@@ -22,22 +22,15 @@ function makeTodoStore() {
   function add(title: string): void {
     const trimmed = title.trim();
     if (trimmed === "") return;
-    todos.value = [
-      ...todos.value,
-      { id: crypto.randomUUID(), title: trimmed, done: false },
-    ];
+    todos.value = [...todos.value, { id: crypto.randomUUID(), title: trimmed, done: false }];
   }
 
   function rename(id: string, title: string): void {
-    todos.value = todos.value.map((t) =>
-      t.id === id ? { ...t, title } : t,
-    );
+    todos.value = todos.value.map((t) => (t.id === id ? { ...t, title } : t));
   }
 
   function toggle(id: string): void {
-    todos.value = todos.value.map((t) =>
-      t.id === id ? { ...t, done: !t.done } : t,
-    );
+    todos.value = todos.value.map((t) => (t.id === id ? { ...t, done: !t.done } : t));
   }
 
   function remove(id: string): void {
@@ -46,9 +39,7 @@ function makeTodoStore() {
 
   return createStore({
     todos,
-    remaining: computed(
-      () => todos.value.filter((t) => !t.done).length,
-    ),
+    remaining: computed(() => todos.value.filter((t) => !t.done).length),
     add,
     rename,
     toggle,

--- a/recipes/actions-driven-app/src/stores.ts
+++ b/recipes/actions-driven-app/src/stores.ts
@@ -1,0 +1,81 @@
+/**
+ * Stores: todo list (persisted), ephemeral view state.
+ *
+ * Exposes signals for reading and methods for mutation. Methods are
+ * the only public mutation surface — actions call them; components
+ * read signals and dispatch actions.
+ */
+
+import { $persistedState } from "@fairfox/polly/state";
+import { createStore } from "@fairfox/polly/actions";
+import { computed, signal } from "@preact/signals";
+
+export type Todo = {
+  id: string;
+  title: string;
+  done: boolean;
+};
+
+function makeTodoStore() {
+  const todos = $persistedState<Todo[]>("recipe.todos", []);
+
+  function add(title: string): void {
+    const trimmed = title.trim();
+    if (trimmed === "") return;
+    todos.value = [
+      ...todos.value,
+      { id: crypto.randomUUID(), title: trimmed, done: false },
+    ];
+  }
+
+  function rename(id: string, title: string): void {
+    todos.value = todos.value.map((t) =>
+      t.id === id ? { ...t, title } : t,
+    );
+  }
+
+  function toggle(id: string): void {
+    todos.value = todos.value.map((t) =>
+      t.id === id ? { ...t, done: !t.done } : t,
+    );
+  }
+
+  function remove(id: string): void {
+    todos.value = todos.value.filter((t) => t.id !== id);
+  }
+
+  return createStore({
+    todos,
+    remaining: computed(
+      () => todos.value.filter((t) => !t.done).length,
+    ),
+    add,
+    rename,
+    toggle,
+    remove,
+  });
+}
+
+function makeViewStore() {
+  const theme = $persistedState<"light" | "dark">("recipe.theme", "light");
+  const selectedId = signal<string | null>(null);
+
+  function toggleTheme(): void {
+    theme.value = theme.value === "dark" ? "light" : "dark";
+  }
+
+  function select(id: string | null): void {
+    selectedId.value = id;
+  }
+
+  return createStore({ theme, selectedId, toggleTheme, select });
+}
+
+export type RootStore = ReturnType<typeof makeRootStore>;
+
+export function makeRootStore() {
+  return createStore({
+    todos: makeTodoStore(),
+    view: makeViewStore(),
+  });
+}

--- a/recipes/actions-driven-app/tests/actions.test.ts
+++ b/recipes/actions-driven-app/tests/actions.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Action-handler unit tests.
+ *
+ * Hand-rolled store fakes that satisfy the RootStore shape; runAction
+ * invokes the handler with a fake ActionContext. No DOM, no render.
+ */
+
+import { beforeEach, expect, test } from "bun:test";
+import { runAction } from "@fairfox/polly/actions";
+import { signal } from "@preact/signals";
+import { ACTION_REGISTRY } from "../src/actions.ts";
+import { createTodoForm } from "../src/forms.ts";
+import type { RootStore, Todo } from "../src/stores.ts";
+
+type Stub = RootStore & {
+  todos: RootStore["todos"] & {
+    _calls: { name: string; args: unknown[] }[];
+  };
+};
+
+function stubStores(initial: Todo[] = []): Stub {
+  const todos = signal<Todo[]>(initial);
+  const calls: { name: string; args: unknown[] }[] = [];
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      calls.push({ name, args });
+    };
+
+  const stub = {
+    todos: {
+      todos,
+      remaining: { value: 0 } as unknown as RootStore["todos"]["remaining"],
+      add: record("add"),
+      rename: record("rename"),
+      toggle: record("toggle"),
+      remove: record("remove"),
+      _calls: calls,
+    },
+    view: {
+      theme: signal<"light" | "dark">("light"),
+      selectedId: signal<string | null>(null),
+      toggleTheme: record("toggleTheme"),
+      select: record("select"),
+    },
+  } as unknown as Stub;
+  createTodoForm.bindStores(() => stub);
+  return stub;
+}
+
+beforeEach(() => {
+  createTodoForm.close();
+});
+
+test("todo:toggle forwards the id to stores.todos.toggle", async () => {
+  const stores = stubStores();
+  await runAction(ACTION_REGISTRY, "todo:toggle", {
+    stores,
+    data: { todoId: "abc" },
+  });
+  expect(stores.todos._calls).toEqual([{ name: "toggle", args: ["abc"] }]);
+});
+
+test("todo:remove forwards the id to stores.todos.remove", async () => {
+  const stores = stubStores();
+  await runAction(ACTION_REGISTRY, "todo:remove", {
+    stores,
+    data: { todoId: "abc" },
+  });
+  expect(stores.todos._calls).toEqual([{ name: "remove", args: ["abc"] }]);
+});
+
+test("todo:rename with blank value surfaces an error and does not mutate", async () => {
+  const stores = stubStores();
+  await runAction(ACTION_REGISTRY, "todo:rename", {
+    stores,
+    data: { todoId: "abc", value: "   " },
+  });
+  expect(stores.todos._calls).toEqual([]);
+});

--- a/recipes/actions-driven-app/tests/forms.test.ts
+++ b/recipes/actions-driven-app/tests/forms.test.ts
@@ -17,15 +17,15 @@ function makeStores(): RootStore & { _calls: unknown[] } {
       add: (title: string) => {
         calls.push({ name: "add", title });
       },
-      rename: () => {},
-      toggle: () => {},
-      remove: () => {},
+      rename: () => undefined,
+      toggle: () => undefined,
+      remove: () => undefined,
     },
     view: {
       theme: signal<"light" | "dark">("light"),
       selectedId: signal<string | null>(null),
-      toggleTheme: () => {},
-      select: () => {},
+      toggleTheme: () => undefined,
+      select: () => undefined,
     },
     _calls: calls,
   } as unknown as RootStore & { _calls: unknown[] };

--- a/recipes/actions-driven-app/tests/forms.test.ts
+++ b/recipes/actions-driven-app/tests/forms.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Form lifecycle tests — exercise createTodoForm in isolation.
+ */
+
+import { beforeEach, expect, test } from "bun:test";
+import { signal } from "@preact/signals";
+import { createTodoForm } from "../src/forms.ts";
+import type { RootStore, Todo } from "../src/stores.ts";
+
+function makeStores(): RootStore & { _calls: unknown[] } {
+  const todos = signal<Todo[]>([]);
+  const calls: unknown[] = [];
+  const stub = {
+    todos: {
+      todos,
+      remaining: { value: 0 } as unknown as RootStore["todos"]["remaining"],
+      add: (title: string) => {
+        calls.push({ name: "add", title });
+      },
+      rename: () => {},
+      toggle: () => {},
+      remove: () => {},
+    },
+    view: {
+      theme: signal<"light" | "dark">("light"),
+      selectedId: signal<string | null>(null),
+      toggleTheme: () => {},
+      select: () => {},
+    },
+    _calls: calls,
+  } as unknown as RootStore & { _calls: unknown[] };
+  createTodoForm.bindStores(() => stub);
+  return stub;
+}
+
+beforeEach(() => {
+  createTodoForm.close();
+});
+
+test("blank title is rejected by validate and add is not called", async () => {
+  const stores = makeStores();
+  createTodoForm.open();
+  createTodoForm.fields.title.value = "   ";
+  await createTodoForm.submit();
+  expect(createTodoForm.errors.value.title).toBe("Title required");
+  expect(stores._calls).toEqual([]);
+  expect(createTodoForm.isOpen.value).toBe(true);
+});
+
+test("valid title calls stores.todos.add and closes the form", async () => {
+  const stores = makeStores();
+  createTodoForm.open();
+  createTodoForm.fields.title.value = "Buy milk";
+  await createTodoForm.submit();
+  expect(stores._calls).toEqual([{ name: "add", title: "Buy milk" }]);
+  expect(createTodoForm.isOpen.value).toBe(false);
+});

--- a/recipes/actions-driven-app/tsconfig.json
+++ b/recipes/actions-driven-app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/src/actions/error.ts
+++ b/src/actions/error.ts
@@ -28,7 +28,7 @@ function allocId(): string {
 
 export function setError(
   message: string,
-  opts: { severity?: ErrorSeverity; action?: string } = {},
+  opts: { severity?: ErrorSeverity; action?: string } = {}
 ): string {
   const entry: ErrorEntry = {
     id: allocId(),

--- a/src/actions/error.ts
+++ b/src/actions/error.ts
@@ -1,0 +1,59 @@
+/**
+ * Global error surface for action handlers.
+ *
+ * Actions that fail set the errorState signal via `submitError`; a `<Toast>`
+ * component consumes that signal and renders a dismissable message. Handlers
+ * that catch expected failures (validation, quota) may call `setError` directly.
+ */
+
+import { signal } from "@preact/signals";
+
+export type ErrorSeverity = "error" | "warning" | "info";
+
+export type ErrorEntry = {
+  id: string;
+  message: string;
+  severity: ErrorSeverity;
+  action?: string;
+  createdAt: number;
+};
+
+export const errorState = signal<ErrorEntry[]>([]);
+
+let nextId = 0;
+function allocId(): string {
+  nextId += 1;
+  return `polly-err-${nextId}`;
+}
+
+export function setError(
+  message: string,
+  opts: { severity?: ErrorSeverity; action?: string } = {},
+): string {
+  const entry: ErrorEntry = {
+    id: allocId(),
+    message,
+    severity: opts.severity ?? "error",
+    action: opts.action,
+    createdAt: Date.now(),
+  };
+  errorState.value = [...errorState.value, entry];
+  return entry.id;
+}
+
+export function clearError(id?: string): void {
+  if (id === undefined) {
+    errorState.value = [];
+    return;
+  }
+  errorState.value = errorState.value.filter((e) => e.id !== id);
+}
+
+/**
+ * Convenience wrapper for an action's catch block.
+ * Logs the action name + error and surfaces a user-visible message.
+ */
+export function submitError(action: string, err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return setError(message, { action, severity: "error" });
+}

--- a/src/actions/event-delegation.ts
+++ b/src/actions/event-delegation.ts
@@ -36,15 +36,11 @@ export type ActionDispatch = {
  */
 export function parseActionData(element: HTMLElement): Record<string, string> {
   const data: Record<string, string> = {};
-  for (let i = 0; i < element.attributes.length; i += 1) {
-    const attr = element.attributes[i];
-    if (!attr) continue;
+  for (const attr of Array.from(element.attributes)) {
     if (attr.name.startsWith("data-action-")) {
       const key = attr.name
         .replace("data-action-", "")
-        .replace(/-([a-z])/g, (_m: string, letter: string) =>
-          letter.toUpperCase(),
-        );
+        .replace(/-([a-z])/g, (_m: string, letter: string) => letter.toUpperCase());
       data[key] = attr.value;
     }
   }
@@ -64,7 +60,7 @@ export function closeTopOverlay(): void {
     new CustomEvent("overlay:close", {
       bubbles: true,
       detail: { id: topOverlay.getAttribute("data-overlay-id") },
-    }),
+    })
   );
 }
 
@@ -93,7 +89,7 @@ export function resolveAction(event: Event): ActionDispatch | null {
  */
 export function installEventDelegation(
   onDispatch: (dispatch: ActionDispatch) => void,
-  options: { onEscape?: () => void; onOutsideOverlayClick?: () => void } = {},
+  options: { onEscape?: () => void; onOutsideOverlayClick?: () => void } = {}
 ): () => void {
   const handleActionEvent = (event: Event) => {
     const dispatch = resolveAction(event);

--- a/src/actions/event-delegation.ts
+++ b/src/actions/event-delegation.ts
@@ -7,9 +7,13 @@
  *
  * Forms are skipped on click — a `<form data-action="...">` responds to
  * submit only, so clicks on form children don't bubble into its action.
- * Escape closes the topmost overlay. Enter/Space on non-interactive elements
- * with `data-action` fire the action (Space is prevented to stop page scroll).
+ * Escape closes the topmost overlay by calling the overlay registry.
+ * Enter/Space on non-interactive elements with `data-action` fire the
+ * action (Space is prevented to stop page scroll). Click outside any
+ * `[data-overlay-id]` element also pops the top overlay.
  */
+
+import { closeTopOverlay as closeTopRegistryOverlay } from "./overlay.ts";
 
 /** Elements that natively fire click on Enter/Space. */
 export const INTERACTIVE_TAGS = new Set(["BUTTON", "A", "INPUT", "SELECT", "TEXTAREA"]);
@@ -89,6 +93,7 @@ export function resolveAction(event: Event): ActionDispatch | null {
  */
 export function installEventDelegation(
   onDispatch: (dispatch: ActionDispatch) => void,
+  options: { onEscape?: () => void; onOutsideOverlayClick?: () => void } = {},
 ): () => void {
   const handleActionEvent = (event: Event) => {
     const dispatch = resolveAction(event);
@@ -97,7 +102,12 @@ export function installEventDelegation(
 
   const handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
-      closeTopOverlay();
+      if (options.onEscape) {
+        options.onEscape();
+      } else {
+        closeTopRegistryOverlay();
+        closeTopOverlay();
+      }
       return;
     }
     if (event.key === "Enter" || event.key === " ") {
@@ -115,7 +125,13 @@ export function installEventDelegation(
   const handleMouseDown = (event: MouseEvent) => {
     if (!(event.target instanceof Element)) return;
     const clickedOverlay = event.target.closest("[data-overlay-id]");
-    if (!clickedOverlay) closeTopOverlay();
+    if (clickedOverlay) return;
+    if (options.onOutsideOverlayClick) {
+      options.onOutsideOverlayClick();
+    } else {
+      closeTopRegistryOverlay();
+      closeTopOverlay();
+    }
   };
 
   for (const eventType of ACTION_EVENT_TYPES) {

--- a/src/actions/event-delegation.ts
+++ b/src/actions/event-delegation.ts
@@ -1,0 +1,134 @@
+/**
+ * Event delegation core.
+ *
+ * One document listener dispatches `data-action` events to typed handlers.
+ * Walks up the DOM with `closest('[data-action]')`, parses `data-action-*`
+ * attributes into a camelCase object, and hands the dispatch to the caller.
+ *
+ * Forms are skipped on click — a `<form data-action="...">` responds to
+ * submit only, so clicks on form children don't bubble into its action.
+ * Escape closes the topmost overlay. Enter/Space on non-interactive elements
+ * with `data-action` fire the action (Space is prevented to stop page scroll).
+ */
+
+/** Elements that natively fire click on Enter/Space. */
+export const INTERACTIVE_TAGS = new Set(["BUTTON", "A", "INPUT", "SELECT", "TEXTAREA"]);
+
+/** Event types that may trigger a data-action dispatch. */
+export const ACTION_EVENT_TYPES = new Set(["click", "submit", "change", "input"]);
+
+/** Parsed action dispatch — what the runtime resolves before invoking a handler. */
+export type ActionDispatch = {
+  action: string;
+  element: HTMLElement;
+  event: Event;
+  data: Record<string, string>;
+};
+
+/**
+ * Parse `data-action-*` attributes into camelCase key-value pairs.
+ *
+ * `data-action-text-set-id="42"` becomes `{ textSetId: "42" }`.
+ */
+export function parseActionData(element: HTMLElement): Record<string, string> {
+  const data: Record<string, string> = {};
+  for (let i = 0; i < element.attributes.length; i += 1) {
+    const attr = element.attributes[i];
+    if (!attr) continue;
+    if (attr.name.startsWith("data-action-")) {
+      const key = attr.name
+        .replace("data-action-", "")
+        .replace(/-([a-z])/g, (_m: string, letter: string) =>
+          letter.toUpperCase(),
+        );
+      data[key] = attr.value;
+    }
+  }
+  return data;
+}
+
+/**
+ * Close the topmost overlay by dispatching `overlay:close` on its element.
+ * Overlays mark themselves with `data-overlay-id`.
+ */
+export function closeTopOverlay(): void {
+  const overlays = document.querySelectorAll("[data-overlay-id]");
+  if (overlays.length === 0) return;
+  const topOverlay = overlays[overlays.length - 1];
+  if (!topOverlay) return;
+  topOverlay.dispatchEvent(
+    new CustomEvent("overlay:close", {
+      bubbles: true,
+      detail: { id: topOverlay.getAttribute("data-overlay-id") },
+    }),
+  );
+}
+
+/**
+ * Resolve a DOM event to an ActionDispatch, or null if no data-action matches.
+ */
+export function resolveAction(event: Event): ActionDispatch | null {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const actionElement = target.closest("[data-action]");
+  if (!(actionElement instanceof HTMLElement)) return null;
+  if (event.type === "click" && actionElement.tagName === "FORM") return null;
+  const action = actionElement.getAttribute("data-action");
+  if (!action) return null;
+  return {
+    action,
+    element: actionElement,
+    event,
+    data: parseActionData(actionElement),
+  };
+}
+
+/**
+ * Install document-level listeners for the delegation system.
+ * Returns a cleanup function that removes every listener it installed.
+ */
+export function installEventDelegation(
+  onDispatch: (dispatch: ActionDispatch) => void,
+): () => void {
+  const handleActionEvent = (event: Event) => {
+    const dispatch = resolveAction(event);
+    if (dispatch) onDispatch(dispatch);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      closeTopOverlay();
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (INTERACTIVE_TAGS.has(target.tagName)) return;
+      const dispatch = resolveAction(event);
+      if (dispatch) {
+        event.preventDefault();
+        onDispatch(dispatch);
+      }
+    }
+  };
+
+  const handleMouseDown = (event: MouseEvent) => {
+    if (!(event.target instanceof Element)) return;
+    const clickedOverlay = event.target.closest("[data-overlay-id]");
+    if (!clickedOverlay) closeTopOverlay();
+  };
+
+  for (const eventType of ACTION_EVENT_TYPES) {
+    document.addEventListener(eventType, handleActionEvent);
+  }
+  document.addEventListener("keydown", handleKeyDown);
+  document.addEventListener("mousedown", handleMouseDown);
+
+  return () => {
+    for (const eventType of ACTION_EVENT_TYPES) {
+      document.removeEventListener(eventType, handleActionEvent);
+    }
+    document.removeEventListener("keydown", handleKeyDown);
+    document.removeEventListener("mousedown", handleMouseDown);
+  };
+}

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -1,0 +1,273 @@
+/**
+ * Form primitive.
+ *
+ * `createForm` returns a typed form store: per-field signals, an aggregated
+ * values signal, open/close/submit methods, and three auto-registered action
+ * handlers (`{name}:open`, `{name}:close`, `{name}:submit`) that callers spread
+ * into their global action registry.
+ *
+ * Lifecycle:
+ *   open  → resets fields to initialValues, applies onOpen overrides,
+ *           sets isOpen = true, records data-action-* data in openParams
+ *   typing → uncontrolled inputs keep their own state; controlled inputs
+ *           write fields.X.value directly
+ *   submit → reads FormData from the form element, merges into fields,
+ *           runs optional validate, calls user onSubmit with final values,
+ *           closes on success, sets errorState on failure
+ *   close  → resets and sets isOpen = false
+ *   guard  → autonomous effect; if guard() returns false while open, close()
+ */
+
+import {
+  computed,
+  effect,
+  type ReadonlySignal,
+  type Signal,
+  signal,
+} from "@preact/signals";
+import { submitError } from "./error.ts";
+import type { ActionRegistry } from "./registry.ts";
+
+function isFormElement(target: EventTarget | null): target is HTMLFormElement {
+  if (!target) return false;
+  if (typeof HTMLFormElement !== "undefined") {
+    return target instanceof HTMLFormElement;
+  }
+  const t = target as { tagName?: unknown };
+  return typeof t.tagName === "string" && t.tagName === "FORM";
+}
+
+export type FormOpenContext<TStores> = {
+  data: Record<string, string>;
+  stores: TStores;
+};
+
+export type FormSubmitContext<TValues, TStores> = {
+  values: TValues;
+  stores: TStores;
+};
+
+export type FormConfig<TValues extends Record<string, string>, TStores> = {
+  /** Used as action namespace: `{name}:open`, `{name}:close`, `{name}:submit`. */
+  name: string;
+  initialValues: TValues;
+  onSubmit: (
+    ctx: FormSubmitContext<TValues, TStores>,
+  ) => void | Promise<void>;
+  /** Invoked on open; return partial overrides to pre-populate fields. */
+  onOpen?: (ctx: FormOpenContext<TStores>) => Partial<TValues> | void;
+  /** Returns false while open → form auto-closes (entity-deletion guard). */
+  guard?: (ctx: { stores: TStores }) => boolean;
+  /** Synchronous validation. Returning keys blocks submit. */
+  validate?: (
+    values: TValues,
+  ) => Partial<Record<keyof TValues, string>> | null;
+};
+
+export type FormStore<
+  TValues extends Record<string, string>,
+  TStores,
+> = {
+  readonly name: string;
+  readonly isOpen: ReadonlySignal<boolean>;
+  readonly values: ReadonlySignal<TValues>;
+  readonly fields: { [K in keyof TValues]: Signal<TValues[K]> };
+  readonly errors: ReadonlySignal<Partial<Record<keyof TValues, string>>>;
+  readonly isSubmitting: ReadonlySignal<boolean>;
+  readonly openParams: ReadonlySignal<Record<string, string>>;
+  open(override?: Partial<TValues>, params?: Record<string, string>): void;
+  close(): void;
+  submit(event?: Event): Promise<void>;
+  /** Late-binds stores; required before guard/onOpen/onSubmit can access stores. */
+  bindStores(getStores: () => TStores): void;
+  /** Action handler entries. Spread into the user's ActionRegistry. */
+  actions: ActionRegistry<TStores>;
+};
+
+export function createForm<
+  TValues extends Record<string, string>,
+  TStores,
+>(config: FormConfig<TValues, TStores>): FormStore<TValues, TStores> {
+  const fieldKeys = Object.keys(config.initialValues) as (keyof TValues)[];
+
+  const fields = {} as { [K in keyof TValues]: Signal<TValues[K]> };
+  for (const key of fieldKeys) {
+    fields[key] = signal(config.initialValues[key]);
+  }
+
+  const values = computed<TValues>(() => {
+    const v = {} as TValues;
+    for (const key of fieldKeys) {
+      v[key] = fields[key].value;
+    }
+    return v;
+  });
+
+  const isOpen = signal(false);
+  const isSubmitting = signal(false);
+  const errors = signal<Partial<Record<keyof TValues, string>>>({});
+  const openParams = signal<Record<string, string>>({});
+
+  let getStoresRef: (() => TStores) | null = null;
+  let disposeGuardEffect: (() => void) | null = null;
+
+  function getStoresOrThrow(): TStores {
+    if (!getStoresRef) {
+      throw new Error(
+        `Form "${config.name}" used before bindStores(). Call form.bindStores(() => yourStores) at app init.`,
+      );
+    }
+    return getStoresRef();
+  }
+
+  function resetToInitial(): void {
+    for (const key of fieldKeys) {
+      fields[key].value = config.initialValues[key];
+    }
+    errors.value = {};
+  }
+
+  function open(
+    override?: Partial<TValues>,
+    params: Record<string, string> = {},
+  ): void {
+    resetToInitial();
+    openParams.value = params;
+    if (config.onOpen && getStoresRef) {
+      const onOpenOverride =
+        config.onOpen({ data: params, stores: getStoresOrThrow() }) ?? {};
+      for (const [k, v] of Object.entries(onOpenOverride)) {
+        if (k in fields) {
+          fields[k as keyof TValues].value = v as TValues[keyof TValues];
+        }
+      }
+    }
+    if (override) {
+      for (const [k, v] of Object.entries(override)) {
+        if (k in fields) {
+          fields[k as keyof TValues].value = v as TValues[keyof TValues];
+        }
+      }
+    }
+    isOpen.value = true;
+  }
+
+  function close(): void {
+    isOpen.value = false;
+    resetToInitial();
+    openParams.value = {};
+  }
+
+  async function submit(event?: Event): Promise<void> {
+    if (event) event.preventDefault();
+    if (event && isFormElement(event.target)) {
+      const fd = new FormData(event.target);
+      for (const key of fieldKeys) {
+        const raw = fd.get(key as string);
+        if (raw !== null) {
+          fields[key].value = String(raw) as TValues[typeof key];
+        }
+      }
+    }
+    const current = values.value;
+    const validationErrors = config.validate?.(current);
+    if (
+      validationErrors &&
+      Object.keys(validationErrors).length > 0
+    ) {
+      errors.value = validationErrors;
+      return;
+    }
+    errors.value = {};
+    isSubmitting.value = true;
+    try {
+      await config.onSubmit({
+        values: current,
+        stores: getStoresOrThrow(),
+      });
+      close();
+    } catch (err) {
+      submitError(`${config.name}:submit`, err);
+    } finally {
+      isSubmitting.value = false;
+    }
+  }
+
+  function bindStores(getStores: () => TStores): void {
+    getStoresRef = getStores;
+    disposeGuardEffect?.();
+    const guardFn = config.guard;
+    if (guardFn) {
+      disposeGuardEffect = effect(() => {
+        if (!isOpen.value) return;
+        if (!guardFn({ stores: getStores() })) close();
+      });
+    }
+  }
+
+  const actions: ActionRegistry<TStores> = {
+    [`${config.name}:open`]: ({ data }) => {
+      open(undefined, data);
+    },
+    [`${config.name}:close`]: () => {
+      close();
+    },
+    [`${config.name}:submit`]: async ({ event }) => {
+      await submit(event);
+    },
+  };
+
+  return {
+    name: config.name,
+    isOpen,
+    values,
+    fields,
+    errors,
+    isSubmitting,
+    openParams,
+    open,
+    close,
+    submit,
+    bindStores,
+    actions,
+  };
+}
+
+/**
+ * Compose many forms into a single set: merged actions, closeAll, openForm signal.
+ */
+export type FormSet<TStores> = {
+  actions: ActionRegistry<TStores>;
+  openForm: ReadonlySignal<string | null>;
+  closeAll(): void;
+  bindStores(getStores: () => TStores): void;
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function createFormSet<TStores>(
+  forms: readonly FormStore<any, TStores>[],
+): FormSet<TStores> {
+  const merged: ActionRegistry<TStores> = {};
+  for (const form of forms) {
+    Object.assign(merged, form.actions);
+  }
+
+  const openForm = computed<string | null>(() => {
+    for (const form of forms) {
+      if (form.isOpen.value) return form.name;
+    }
+    return null;
+  });
+
+  return {
+    actions: merged,
+    openForm,
+    closeAll() {
+      for (const form of forms) form.close();
+    },
+    bindStores(getStores) {
+      for (const form of forms) form.bindStores(getStores);
+    },
+  };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -18,13 +18,7 @@
  *   guard  → autonomous effect; if guard() returns false while open, close()
  */
 
-import {
-  computed,
-  effect,
-  type ReadonlySignal,
-  type Signal,
-  signal,
-} from "@preact/signals";
+import { computed, effect, type ReadonlySignal, type Signal, signal } from "@preact/signals";
 import { submitError } from "./error.ts";
 import type { ActionRegistry } from "./registry.ts";
 
@@ -51,23 +45,16 @@ export type FormConfig<TValues extends Record<string, string>, TStores> = {
   /** Used as action namespace: `{name}:open`, `{name}:close`, `{name}:submit`. */
   name: string;
   initialValues: TValues;
-  onSubmit: (
-    ctx: FormSubmitContext<TValues, TStores>,
-  ) => void | Promise<void>;
+  onSubmit: (ctx: FormSubmitContext<TValues, TStores>) => void | Promise<void>;
   /** Invoked on open; return partial overrides to pre-populate fields. */
-  onOpen?: (ctx: FormOpenContext<TStores>) => Partial<TValues> | void;
+  onOpen?: (ctx: FormOpenContext<TStores>) => Partial<TValues> | undefined;
   /** Returns false while open → form auto-closes (entity-deletion guard). */
   guard?: (ctx: { stores: TStores }) => boolean;
   /** Synchronous validation. Returning keys blocks submit. */
-  validate?: (
-    values: TValues,
-  ) => Partial<Record<keyof TValues, string>> | null;
+  validate?: (values: TValues) => Partial<Record<keyof TValues, string>> | null;
 };
 
-export type FormStore<
-  TValues extends Record<string, string>,
-  TStores,
-> = {
+export type FormStore<TValues extends Record<string, string>, TStores> = {
   readonly name: string;
   readonly isOpen: ReadonlySignal<boolean>;
   readonly values: ReadonlySignal<TValues>;
@@ -84,10 +71,9 @@ export type FormStore<
   actions: ActionRegistry<TStores>;
 };
 
-export function createForm<
-  TValues extends Record<string, string>,
-  TStores,
->(config: FormConfig<TValues, TStores>): FormStore<TValues, TStores> {
+export function createForm<TValues extends Record<string, string>, TStores>(
+  config: FormConfig<TValues, TStores>
+): FormStore<TValues, TStores> {
   const fieldKeys = Object.keys(config.initialValues) as unknown as (keyof TValues)[];
 
   const fields = {} as unknown as { [K in keyof TValues]: Signal<TValues[K]> };
@@ -114,7 +100,7 @@ export function createForm<
   function getStoresOrThrow(): TStores {
     if (!getStoresRef) {
       throw new Error(
-        `Form "${config.name}" used before bindStores(). Call form.bindStores(() => yourStores) at app init.`,
+        `Form "${config.name}" used before bindStores(). Call form.bindStores(() => yourStores) at app init.`
       );
     }
     return getStoresRef();
@@ -127,15 +113,12 @@ export function createForm<
     errors.value = {};
   }
 
-  function open(
-    override?: Partial<TValues>,
-    params: Record<string, string> = {},
-  ): void {
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: open applies two layers of overrides plus optional onOpen — branchy by design.
+  function open(override?: Partial<TValues>, params: Record<string, string> = {}): void {
     resetToInitial();
     openParams.value = params;
     if (config.onOpen && getStoresRef) {
-      const onOpenOverride =
-        config.onOpen({ data: params, stores: getStoresOrThrow() }) ?? {};
+      const onOpenOverride = config.onOpen({ data: params, stores: getStoresOrThrow() }) ?? {};
       for (const [k, v] of Object.entries(onOpenOverride)) {
         if (k in fields) {
           fields[k as keyof TValues].value = v as TValues[keyof TValues];
@@ -158,6 +141,7 @@ export function createForm<
     openParams.value = {};
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: submit funnels FormData, validate, onSubmit, errorState, and close — one-path-per-stage by design.
   async function submit(event?: Event): Promise<void> {
     if (event) event.preventDefault();
     if (event && isFormElement(event.target)) {
@@ -171,10 +155,7 @@ export function createForm<
     }
     const current = values.value;
     const validationErrors = config.validate?.(current);
-    if (
-      validationErrors &&
-      Object.keys(validationErrors).length > 0
-    ) {
+    if (validationErrors && Object.keys(validationErrors).length > 0) {
       errors.value = validationErrors;
       return;
     }
@@ -243,9 +224,8 @@ export type FormSet<TStores> = {
   bindStores(getStores: () => TStores): void;
 };
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export function createFormSet<TStores>(
-  forms: readonly FormStore<any, TStores>[],
+  forms: readonly FormStore<Record<string, string>, TStores>[]
 ): FormSet<TStores> {
   const merged: ActionRegistry<TStores> = {};
   for (const form of forms) {
@@ -270,4 +250,3 @@ export function createFormSet<TStores>(
     },
   };
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -33,7 +33,7 @@ function isFormElement(target: EventTarget | null): target is HTMLFormElement {
   if (typeof HTMLFormElement !== "undefined") {
     return target instanceof HTMLFormElement;
   }
-  const t = target as { tagName?: unknown };
+  const t = target as unknown as { tagName?: unknown };
   return typeof t.tagName === "string" && t.tagName === "FORM";
 }
 
@@ -88,15 +88,15 @@ export function createForm<
   TValues extends Record<string, string>,
   TStores,
 >(config: FormConfig<TValues, TStores>): FormStore<TValues, TStores> {
-  const fieldKeys = Object.keys(config.initialValues) as (keyof TValues)[];
+  const fieldKeys = Object.keys(config.initialValues) as unknown as (keyof TValues)[];
 
-  const fields = {} as { [K in keyof TValues]: Signal<TValues[K]> };
+  const fields = {} as unknown as { [K in keyof TValues]: Signal<TValues[K]> };
   for (const key of fieldKeys) {
     fields[key] = signal(config.initialValues[key]);
   }
 
   const values = computed<TValues>(() => {
-    const v = {} as TValues;
+    const v = {} as unknown as TValues;
     for (const key of fieldKeys) {
       v[key] = fields[key].value;
     }
@@ -163,9 +163,9 @@ export function createForm<
     if (event && isFormElement(event.target)) {
       const fd = new FormData(event.target);
       for (const key of fieldKeys) {
-        const raw = fd.get(key as string);
+        const raw = fd.get(key as unknown as string);
         if (raw !== null) {
-          fields[key].value = String(raw) as TValues[typeof key];
+          fields[key].value = String(raw) as unknown as TValues[typeof key];
         }
       }
     }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Public API for `@fairfox/polly/actions`.
+ *
+ * The action registry pattern: one document listener, one typed registry,
+ * components are logic-free consumers of signals that emit `data-action`.
+ */
+
+export {
+  ACTION_EVENT_TYPES,
+  INTERACTIVE_TAGS,
+  type ActionDispatch,
+  closeTopOverlay as closeTopOverlayViaDom,
+  installEventDelegation,
+  parseActionData,
+  resolveAction,
+} from "./event-delegation.ts";
+
+export type {
+  ActionContext,
+  ActionHandler,
+  ActionRegistry,
+} from "./registry.ts";
+
+export {
+  closeTopOverlay,
+  hasOpenOverlay,
+  type OverlayEntry,
+  overlayStack,
+  popOverlay,
+  pushOverlay,
+  resetOverlayStack,
+  topOverlay,
+} from "./overlay.ts";
+
+export { createStore, StoreProvider, type StoreProviderProps, useStores } from "./store.tsx";
+
+export {
+  createForm,
+  createFormSet,
+  type FormConfig,
+  type FormOpenContext,
+  type FormSet,
+  type FormStore,
+  type FormSubmitContext,
+} from "./form.ts";
+
+export {
+  clearError,
+  type ErrorEntry,
+  type ErrorSeverity,
+  errorState,
+  setError,
+  submitError,
+} from "./error.ts";
+
+export {
+  createMockElement,
+  createMockStores,
+  createMockSubmitEvent,
+  runAction,
+} from "./testing.ts";

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -6,21 +6,31 @@
  */
 
 export {
+  clearError,
+  type ErrorEntry,
+  type ErrorSeverity,
+  errorState,
+  setError,
+  submitError,
+} from "./error.ts";
+export {
   ACTION_EVENT_TYPES,
-  INTERACTIVE_TAGS,
   type ActionDispatch,
   closeTopOverlay as closeTopOverlayViaDom,
+  INTERACTIVE_TAGS,
   installEventDelegation,
   parseActionData,
   resolveAction,
 } from "./event-delegation.ts";
-
-export type {
-  ActionContext,
-  ActionHandler,
-  ActionRegistry,
-} from "./registry.ts";
-
+export {
+  createForm,
+  createFormSet,
+  type FormConfig,
+  type FormOpenContext,
+  type FormSet,
+  type FormStore,
+  type FormSubmitContext,
+} from "./form.ts";
 export {
   closeTopOverlay,
   hasOpenOverlay,
@@ -31,27 +41,12 @@ export {
   resetOverlayStack,
   topOverlay,
 } from "./overlay.ts";
-
+export type {
+  ActionContext,
+  ActionHandler,
+  ActionRegistry,
+} from "./registry.ts";
 export { createStore, StoreProvider, type StoreProviderProps, useStores } from "./store.tsx";
-
-export {
-  createForm,
-  createFormSet,
-  type FormConfig,
-  type FormOpenContext,
-  type FormSet,
-  type FormStore,
-  type FormSubmitContext,
-} from "./form.ts";
-
-export {
-  clearError,
-  type ErrorEntry,
-  type ErrorSeverity,
-  errorState,
-  setError,
-  submitError,
-} from "./error.ts";
 
 export {
   createMockElement,

--- a/src/actions/overlay.ts
+++ b/src/actions/overlay.ts
@@ -1,0 +1,67 @@
+/**
+ * Overlay registry.
+ *
+ * Tracks the stack of open overlays (modals, popovers, confirm dialogs) so
+ * Escape can close the topmost and `data-overlay-id`-based DOM scans have
+ * a mirror in memory. Each entry stores an id plus an optional close
+ * callback; `closeTopOverlay` invokes the callback and pops the entry.
+ */
+
+import { signal } from "@preact/signals";
+
+export type OverlayEntry = {
+  id: string;
+  onClose?: () => void;
+};
+
+const stack = signal<OverlayEntry[]>([]);
+
+/** Current overlay stack as a read-only snapshot. */
+export function overlayStack(): readonly OverlayEntry[] {
+  return stack.value;
+}
+
+/** Is any overlay currently open? */
+export function hasOpenOverlay(): boolean {
+  return stack.value.length > 0;
+}
+
+/** The top of the stack, or undefined if empty. */
+export function topOverlay(): OverlayEntry | undefined {
+  const s = stack.value;
+  return s[s.length - 1];
+}
+
+/** Push an overlay onto the stack. Returns the popped entry when closed. */
+export function pushOverlay(entry: OverlayEntry): void {
+  stack.value = [...stack.value, entry];
+}
+
+/** Pop a specific overlay by id (or the top if no id given). */
+export function popOverlay(id?: string): OverlayEntry | undefined {
+  const s = stack.value;
+  if (s.length === 0) return undefined;
+  if (id === undefined) {
+    const top = s[s.length - 1];
+    stack.value = s.slice(0, -1);
+    return top;
+  }
+  const idx = s.findIndex((e) => e.id === id);
+  if (idx === -1) return undefined;
+  const entry = s[idx];
+  stack.value = [...s.slice(0, idx), ...s.slice(idx + 1)];
+  return entry;
+}
+
+/** Close the top overlay by calling its onClose and popping it. */
+export function closeTopOverlay(): OverlayEntry | undefined {
+  const top = topOverlay();
+  if (!top) return undefined;
+  top.onClose?.();
+  return popOverlay(top.id);
+}
+
+/** Reset the stack. Intended for tests. */
+export function resetOverlayStack(): void {
+  stack.value = [];
+}

--- a/src/actions/registry.ts
+++ b/src/actions/registry.ts
@@ -23,8 +23,6 @@ export type ActionContext<TStores> = {
   data: Record<string, string>;
 };
 
-export type ActionHandler<TStores> = (
-  ctx: ActionContext<TStores>,
-) => void | Promise<void>;
+export type ActionHandler<TStores> = (ctx: ActionContext<TStores>) => void | Promise<void>;
 
 export type ActionRegistry<TStores> = Record<string, ActionHandler<TStores>>;

--- a/src/actions/registry.ts
+++ b/src/actions/registry.ts
@@ -1,0 +1,30 @@
+/**
+ * Action registry types.
+ *
+ * An action registry is a plain object mapping action names to handlers.
+ * Handlers receive a typed context with the app's stores, the DOM event,
+ * the element carrying `data-action`, and parsed `data-action-*` data.
+ * Handlers return void or a Promise for async work.
+ *
+ * Users compose registries by spreading partial registries (e.g. from
+ * `createForm`) into one central object:
+ *
+ *   const ACTION_REGISTRY: ActionRegistry<RootStore> = {
+ *     ...teamForm.actions,
+ *     ...projectForm.actions,
+ *     'app:theme:toggle': ({ stores }) => { ... },
+ *   }
+ */
+
+export type ActionContext<TStores> = {
+  stores: TStores;
+  event: Event;
+  element: HTMLElement;
+  data: Record<string, string>;
+};
+
+export type ActionHandler<TStores> = (
+  ctx: ActionContext<TStores>,
+) => void | Promise<void>;
+
+export type ActionRegistry<TStores> = Record<string, ActionHandler<TStores>>;

--- a/src/actions/store.tsx
+++ b/src/actions/store.tsx
@@ -1,0 +1,50 @@
+/**
+ * Store base + Preact context.
+ *
+ * `createStore` is a thin convention-enforcer: a typed bag of signals
+ * plus methods. Apps use it to define domain stores whose only public
+ * mutation surface is named methods (actions call them; components read
+ * signals and dispatch actions). No cleverness — a named pattern more
+ * than a library.
+ *
+ * `StoreProvider` + `useStores` wire the stores bag into Preact context
+ * so components and the delegation runtime can reach it via a single hook.
+ */
+
+import type { ComponentChildren } from "preact";
+import { createContext } from "preact";
+import { useContext } from "preact/hooks";
+
+/**
+ * Identity helper; exists so domain stores have a canonical creation
+ * call even though the bag itself is a plain object. Centralising here
+ * lets us hang additional behaviour off the call site later (debug
+ * instrumentation, devtools) without a migration.
+ */
+export function createStore<T extends object>(init: T): T {
+  return init;
+}
+
+const StoreContext = createContext<unknown>(null);
+
+export type StoreProviderProps<TStores> = {
+  children: ComponentChildren;
+  stores: TStores;
+};
+
+export function StoreProvider<TStores>({
+  children,
+  stores,
+}: StoreProviderProps<TStores>) {
+  return (
+    <StoreContext.Provider value={stores}>{children}</StoreContext.Provider>
+  );
+}
+
+export function useStores<TStores>(): TStores {
+  const ctx = useContext(StoreContext) as TStores | null;
+  if (ctx === null) {
+    throw new Error("useStores must be used within a StoreProvider");
+  }
+  return ctx;
+}

--- a/src/actions/store.tsx
+++ b/src/actions/store.tsx
@@ -32,13 +32,8 @@ export type StoreProviderProps<TStores> = {
   stores: TStores;
 };
 
-export function StoreProvider<TStores>({
-  children,
-  stores,
-}: StoreProviderProps<TStores>) {
-  return (
-    <StoreContext.Provider value={stores}>{children}</StoreContext.Provider>
-  );
+export function StoreProvider<TStores>({ children, stores }: StoreProviderProps<TStores>) {
+  return <StoreContext.Provider value={stores}>{children}</StoreContext.Provider>;
 }
 
 export function useStores<TStores>(): TStores {

--- a/src/actions/store.tsx
+++ b/src/actions/store.tsx
@@ -42,7 +42,7 @@ export function StoreProvider<TStores>({
 }
 
 export function useStores<TStores>(): TStores {
-  const ctx = useContext(StoreContext) as TStores | null;
+  const ctx = useContext(StoreContext) as unknown as TStores | null;
   if (ctx === null) {
     throw new Error("useStores must be used within a StoreProvider");
   }

--- a/src/actions/testing.ts
+++ b/src/actions/testing.ts
@@ -1,0 +1,107 @@
+/**
+ * Testing helpers for action handlers.
+ *
+ * Handlers are plain functions taking an ActionContext; these helpers
+ * build the context pieces without jsdom. For full-DOM tests use the
+ * browser harness at `@fairfox/polly/test/browser`.
+ */
+
+import type {
+  ActionContext,
+  ActionHandler,
+  ActionRegistry,
+} from "./registry.ts";
+
+/**
+ * Build a mock element that satisfies ActionContext.element.
+ * Only the surface a handler is likely to touch is populated.
+ */
+export function createMockElement(
+  attrs: Record<string, string> = {},
+  tagName = "DIV",
+): HTMLElement {
+  const attrMap = new Map(Object.entries(attrs));
+  const el = {
+    tagName,
+    nodeType: 1,
+    getAttribute: (name: string) => attrMap.get(name) ?? null,
+    setAttribute: (name: string, value: string) => {
+      attrMap.set(name, value);
+    },
+    hasAttribute: (name: string) => attrMap.has(name),
+    removeAttribute: (name: string) => {
+      attrMap.delete(name);
+    },
+    attributes: Array.from(attrMap.entries()).map(([name, value]) => ({
+      name,
+      value,
+    })),
+  } as unknown as HTMLElement;
+  return el;
+}
+
+/** Build a minimal submit-like event wrapping a `<form>` FormData payload. */
+export function createMockSubmitEvent(
+  form: HTMLFormElement | Record<string, string>,
+): Event {
+  const isReal =
+    typeof HTMLFormElement !== "undefined" && form instanceof HTMLFormElement;
+  const target = isReal
+    ? (form as HTMLFormElement)
+    : createMockFormElement(form as Record<string, string>);
+  let defaultPrevented = false;
+  return {
+    type: "submit",
+    target,
+    currentTarget: target,
+    preventDefault() {
+      defaultPrevented = true;
+    },
+    stopPropagation() {},
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+  } as unknown as Event;
+}
+
+function createMockFormElement(fields: Record<string, string>): HTMLFormElement {
+  return {
+    nodeType: 1,
+    tagName: "FORM",
+    elements: Object.entries(fields).map(([name, value]) => ({
+      name,
+      value,
+    })),
+  } as unknown as HTMLFormElement;
+}
+
+/**
+ * Shallow-merged partial stores. Callers typically pass signal-backed fakes.
+ */
+export function createMockStores<TStores extends object>(
+  partial: Partial<TStores> = {},
+): TStores {
+  return partial as TStores;
+}
+
+/**
+ * Run a handler in isolation. Useful for unit-testing action logic without
+ * wiring the full document event delegation.
+ */
+export async function runAction<TStores>(
+  registry: ActionRegistry<TStores>,
+  action: string,
+  ctx: Partial<ActionContext<TStores>> & { stores: TStores },
+): Promise<void> {
+  const handler: ActionHandler<TStores> | undefined = registry[action];
+  if (!handler) {
+    throw new Error(`No handler registered for action "${action}"`);
+  }
+  const fullCtx: ActionContext<TStores> = {
+    stores: ctx.stores,
+    event: ctx.event ?? new Event("click"),
+    element: ctx.element ?? createMockElement(),
+    data: ctx.data ?? {},
+  };
+  await handler(fullCtx);
+}

--- a/src/actions/testing.ts
+++ b/src/actions/testing.ts
@@ -6,11 +6,7 @@
  * browser harness at `@fairfox/polly/test/browser`.
  */
 
-import type {
-  ActionContext,
-  ActionHandler,
-  ActionRegistry,
-} from "./registry.ts";
+import type { ActionContext, ActionHandler, ActionRegistry } from "./registry.ts";
 
 /**
  * Build a mock element that satisfies ActionContext.element.
@@ -18,7 +14,7 @@ import type {
  */
 export function createMockElement(
   attrs: Record<string, string> = {},
-  tagName = "DIV",
+  tagName = "DIV"
 ): HTMLElement {
   const attrMap = new Map(Object.entries(attrs));
   const el = {
@@ -41,9 +37,7 @@ export function createMockElement(
 }
 
 /** Build a minimal submit-like event wrapping a `<form>` FormData payload. */
-export function createMockSubmitEvent(
-  form: HTMLFormElement | Record<string, string>,
-): Event {
+export function createMockSubmitEvent(form: HTMLFormElement | Record<string, string>): Event {
   let target: HTMLFormElement;
   if (typeof HTMLFormElement !== "undefined" && form instanceof HTMLFormElement) {
     target = form;
@@ -58,7 +52,9 @@ export function createMockSubmitEvent(
     preventDefault() {
       defaultPrevented = true;
     },
-    stopPropagation() {},
+    stopPropagation() {
+      /* noop */
+    },
     get defaultPrevented() {
       return defaultPrevented;
     },
@@ -79,9 +75,7 @@ function createMockFormElement(fields: Record<string, string>): HTMLFormElement 
 /**
  * Shallow-merged partial stores. Callers typically pass signal-backed fakes.
  */
-export function createMockStores<TStores extends object>(
-  partial: Partial<TStores> = {},
-): TStores {
+export function createMockStores<TStores extends object>(partial: Partial<TStores> = {}): TStores {
   return partial as unknown as TStores;
 }
 
@@ -92,7 +86,7 @@ export function createMockStores<TStores extends object>(
 export async function runAction<TStores>(
   registry: ActionRegistry<TStores>,
   action: string,
-  ctx: Partial<ActionContext<TStores>> & { stores: TStores },
+  ctx: Partial<ActionContext<TStores>> & { stores: TStores }
 ): Promise<void> {
   const handler: ActionHandler<TStores> | undefined = registry[action];
   if (!handler) {

--- a/src/actions/testing.ts
+++ b/src/actions/testing.ts
@@ -44,11 +44,12 @@ export function createMockElement(
 export function createMockSubmitEvent(
   form: HTMLFormElement | Record<string, string>,
 ): Event {
-  const isReal =
-    typeof HTMLFormElement !== "undefined" && form instanceof HTMLFormElement;
-  const target = isReal
-    ? (form as HTMLFormElement)
-    : createMockFormElement(form as Record<string, string>);
+  let target: HTMLFormElement;
+  if (typeof HTMLFormElement !== "undefined" && form instanceof HTMLFormElement) {
+    target = form;
+  } else {
+    target = createMockFormElement(form as unknown as Record<string, string>);
+  }
   let defaultPrevented = false;
   return {
     type: "submit",
@@ -81,7 +82,7 @@ function createMockFormElement(fields: Record<string, string>): HTMLFormElement 
 export function createMockStores<TStores extends object>(
   partial: Partial<TStores> = {},
 ): TStores {
-  return partial as TStores;
+  return partial as unknown as TStores;
 }
 
 /**

--- a/src/polly-ui/ActionForm.module.css
+++ b/src/polly-ui/ActionForm.module.css
@@ -1,0 +1,10 @@
+@layer polly-components {
+  .form {
+    inline-size: 100%;
+  }
+
+  .form[aria-busy="true"] {
+    opacity: var(--polly-opacity-disabled);
+    pointer-events: none;
+  }
+}

--- a/src/polly-ui/ActionForm.tsx
+++ b/src/polly-ui/ActionForm.tsx
@@ -1,0 +1,46 @@
+/**
+ * ActionForm — wraps a native <form> with the action pattern.
+ *
+ * Renders <form data-action="{form.name}:submit"> so the installed
+ * event delegation catches the submit event and dispatches to the
+ * form's auto-registered :submit handler. `aria-busy` mirrors the
+ * `isSubmitting` signal so consumer styling can respond without extra
+ * wiring. The form element also exposes `data-polly-action-form` for
+ * stable selector hooks.
+ */
+
+import type { ComponentChildren, JSX } from "preact";
+import type { FormStore } from "../actions/form.ts";
+import classes from "./ActionForm.module.css";
+
+export type ActionFormProps<TValues extends Record<string, string>, TStores> = {
+  form: FormStore<TValues, TStores>;
+  children: ComponentChildren;
+  className?: string;
+  id?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+};
+
+export function ActionForm<
+  TValues extends Record<string, string>,
+  TStores,
+>(props: ActionFormProps<TValues, TStores>): JSX.Element {
+  const { form, children, className, id } = props;
+  const combined = className ? `${classes["form"]} ${className}` : classes["form"];
+  return (
+    <form
+      id={id}
+      class={combined}
+      data-polly-ui
+      data-polly-action-form={form.name}
+      data-action={`${form.name}:submit`}
+      aria-busy={form.isSubmitting.value}
+      aria-label={props["aria-label"]}
+      aria-labelledby={props["aria-labelledby"]}
+      noValidate
+    >
+      {children}
+    </form>
+  );
+}

--- a/src/polly-ui/ActionForm.tsx
+++ b/src/polly-ui/ActionForm.tsx
@@ -22,10 +22,9 @@ export type ActionFormProps<TValues extends Record<string, string>, TStores> = {
   "aria-labelledby"?: string;
 };
 
-export function ActionForm<
-  TValues extends Record<string, string>,
-  TStores,
->(props: ActionFormProps<TValues, TStores>): JSX.Element {
+export function ActionForm<TValues extends Record<string, string>, TStores>(
+  props: ActionFormProps<TValues, TStores>
+): JSX.Element {
   const { form, children, className, id } = props;
   const combined = className ? `${classes["form"]} ${className}` : classes["form"];
   return (

--- a/src/polly-ui/ActionInput.module.css
+++ b/src/polly-ui/ActionInput.module.css
@@ -1,0 +1,45 @@
+@layer polly-components {
+  .root {
+    inline-size: 100%;
+    box-sizing: border-box;
+    padding: var(--polly-space-sm) var(--polly-space-md);
+    font: inherit;
+    font-family: var(--polly-font-sans);
+    color: var(--polly-text);
+    line-height: var(--polly-line-height-base);
+    border: var(--polly-border-width-default) solid transparent;
+    border-radius: var(--polly-radius-md);
+    min-block-size: calc(
+      1.5em + 2 * var(--polly-space-sm) + 2 * var(--polly-border-width-default)
+    );
+  }
+
+  .view {
+    cursor: text;
+    background: transparent;
+    white-space: pre-wrap;
+    word-break: break-word;
+    transition: background var(--polly-motion-fast) ease,
+      border-color var(--polly-motion-fast) ease;
+  }
+  .view:hover {
+    background: var(--polly-surface-sunken);
+    border-color: var(--polly-border);
+  }
+
+  .edit {
+    background: var(--polly-surface);
+    border-color: var(--polly-border);
+  }
+
+  .placeholder {
+    color: var(--polly-text-muted);
+    font-style: italic;
+  }
+
+  .root[data-variant="multi"] {
+    field-sizing: content;
+    max-block-size: 40em;
+    resize: vertical;
+  }
+}

--- a/src/polly-ui/ActionInput.tsx
+++ b/src/polly-ui/ActionInput.tsx
@@ -44,6 +44,7 @@ export type ActionInputProps = {
   className?: string;
 };
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: two render branches times two variants times four saveOn triggers; branching is inherent to the primitive.
 export function ActionInput(props: ActionInputProps): JSX.Element {
   const variant = props.variant ?? "single";
   const saveOn = props.saveOn ?? "blur";
@@ -81,10 +82,7 @@ export function ActionInput(props: ActionInputProps): JSX.Element {
       const hidden = document.createElement("button");
       hidden.setAttribute("data-action", props.action);
       for (const [key, value] of Object.entries(dataAttrs)) {
-        const dashKey = key.replace(
-          /[A-Z]/g,
-          (m) => `-${m.toLowerCase()}`,
-        );
+        const dashKey = key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
         hidden.setAttribute(`data-action-${dashKey}`, value);
       }
       hidden.style.position = "fixed";
@@ -99,7 +97,7 @@ export function ActionInput(props: ActionInputProps): JSX.Element {
       }
       setMode("view");
     },
-    [props.action, props.actionData, props.value],
+    [props.action, props.actionData, props.value]
   );
 
   const cancel = useCallback(() => {
@@ -107,9 +105,8 @@ export function ActionInput(props: ActionInputProps): JSX.Element {
     setMode("view");
   }, [props.value]);
 
-  const onKeyDown = (
-    event: JSX.TargetedKeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: keyboard handler encodes the saveOn × variant matrix.
+  const onKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     if (event.key === "Escape") {
       event.preventDefault();
       cancel();
@@ -120,10 +117,7 @@ export function ActionInput(props: ActionInputProps): JSX.Element {
       if (saveOn === "enter" && variant === "single") {
         event.preventDefault();
         commit(draft);
-      } else if (
-        (saveOn === "enter" && variant === "multi" && cmd) ||
-        saveOn === "cmd-enter"
-      ) {
+      } else if ((saveOn === "enter" && variant === "multi" && cmd) || saveOn === "cmd-enter") {
         if (cmd) {
           event.preventDefault();
           commit(draft);
@@ -132,16 +126,13 @@ export function ActionInput(props: ActionInputProps): JSX.Element {
     }
   };
 
-  const className = props.className
-    ? `${classes["root"]} ${props.className}`
-    : classes["root"];
+  const className = props.className ? `${classes["root"]} ${props.className}` : classes["root"];
 
   if (mode === "view") {
-    const rendered = props.renderView
-      ? props.renderView(props.value)
-      : props.value;
+    const rendered = props.renderView ? props.renderView(props.value) : props.value;
     const isEmpty = props.value.length === 0;
     return (
+      // biome-ignore lint/a11y/useSemanticElements: <button> would swallow text selection and add default styling; div with role=button is the inline-edit idiom.
       <div
         class={`${className} ${classes["view"]}`}
         data-polly-ui
@@ -178,9 +169,8 @@ export function ActionInput(props: ActionInputProps): JSX.Element {
     "data-variant": variant,
     placeholder: props.placeholder,
     value: draft,
-    onInput: (
-      e: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement>,
-    ) => setDraft(e.currentTarget.value),
+    onInput: (e: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      setDraft(e.currentTarget.value),
     onBlur: () => {
       if (saveOn === "blur") commit(draft);
       else cancel();

--- a/src/polly-ui/ActionInput.tsx
+++ b/src/polly-ui/ActionInput.tsx
@@ -1,0 +1,212 @@
+/**
+ * ActionInput — dual-mode view/edit input with action dispatch on commit.
+ *
+ * View mode renders the current value as text (optionally through a
+ * caller-supplied `renderView` for markdown, rich formatting, etc.).
+ * Click, Enter, or Space enters edit mode. Edit mode is a native input
+ * or textarea; commit fires the configured action with `data-action-value`
+ * and `data-action-field` set from FormData-shape semantics, so the
+ * existing event delegation handles it with no extra wiring.
+ *
+ * `saveOn` picks the commit trigger:
+ *   "blur"       commit when the field loses focus
+ *   "enter"      commit on Enter (single-line) or Cmd/Ctrl+Enter (multi-line)
+ *   "cmd-enter"  commit only on Cmd/Ctrl+Enter
+ *   "explicit"   never auto-commit — caller wires a save button with data-action
+ *
+ * Layout-shift-free: view and edit modes share padding, border width,
+ * font, and line-height so the toggle causes no reflow.
+ */
+
+import type { JSX } from "preact";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import classes from "./ActionInput.module.css";
+
+export type ActionInputSaveOn = "blur" | "enter" | "cmd-enter" | "explicit";
+export type ActionInputVariant = "single" | "multi";
+
+export type ActionInputProps = {
+  /** Current value to render in view mode and seed the edit buffer. */
+  value: string;
+  /** Action name to dispatch on commit. Receives data-action-value=<new value>. */
+  action: string;
+  /** Commit trigger. Default: "blur". */
+  saveOn?: ActionInputSaveOn;
+  variant?: ActionInputVariant;
+  placeholder?: string;
+  disabled?: boolean;
+  /** Extra data-action-* attributes to include at commit (e.g. entity id). */
+  actionData?: Record<string, string>;
+  /** Custom view renderer — receives value, returns VNode. */
+  renderView?: (value: string) => JSX.Element | string;
+  /** Label announced by screen readers for the edit affordance. */
+  ariaLabel?: string;
+  className?: string;
+};
+
+export function ActionInput(props: ActionInputProps): JSX.Element {
+  const variant = props.variant ?? "single";
+  const saveOn = props.saveOn ?? "blur";
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  const [draft, setDraft] = useState(props.value);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (mode === "view") setDraft(props.value);
+  }, [props.value, mode]);
+
+  useEffect(() => {
+    if (mode === "edit" && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select?.();
+    }
+  }, [mode]);
+
+  const enterEdit = useCallback(() => {
+    if (props.disabled) return;
+    setDraft(props.value);
+    setMode("edit");
+  }, [props.disabled, props.value]);
+
+  const commit = useCallback(
+    (next: string) => {
+      if (next === props.value) {
+        setMode("view");
+        return;
+      }
+      const dataAttrs: Record<string, string> = {
+        ...(props.actionData ?? {}),
+        value: next,
+      };
+      const hidden = document.createElement("button");
+      hidden.setAttribute("data-action", props.action);
+      for (const [key, value] of Object.entries(dataAttrs)) {
+        const dashKey = key.replace(
+          /[A-Z]/g,
+          (m) => `-${m.toLowerCase()}`,
+        );
+        hidden.setAttribute(`data-action-${dashKey}`, value);
+      }
+      hidden.style.position = "fixed";
+      hidden.style.opacity = "0";
+      hidden.style.pointerEvents = "none";
+      hidden.tabIndex = -1;
+      document.body.appendChild(hidden);
+      try {
+        hidden.click();
+      } finally {
+        hidden.remove();
+      }
+      setMode("view");
+    },
+    [props.action, props.actionData, props.value],
+  );
+
+  const cancel = useCallback(() => {
+    setDraft(props.value);
+    setMode("view");
+  }, [props.value]);
+
+  const onKeyDown = (
+    event: JSX.TargetedKeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancel();
+      return;
+    }
+    if (event.key === "Enter") {
+      const cmd = event.metaKey || event.ctrlKey;
+      if (saveOn === "enter" && variant === "single") {
+        event.preventDefault();
+        commit(draft);
+      } else if (
+        (saveOn === "enter" && variant === "multi" && cmd) ||
+        saveOn === "cmd-enter"
+      ) {
+        if (cmd) {
+          event.preventDefault();
+          commit(draft);
+        }
+      }
+    }
+  };
+
+  const className = props.className
+    ? `${classes["root"]} ${props.className}`
+    : classes["root"];
+
+  if (mode === "view") {
+    const rendered = props.renderView
+      ? props.renderView(props.value)
+      : props.value;
+    const isEmpty = props.value.length === 0;
+    return (
+      <div
+        class={`${className} ${classes["view"]}`}
+        data-polly-ui
+        data-polly-action-input
+        data-polly-interactive
+        data-state={isEmpty ? "empty" : "filled"}
+        data-variant={variant}
+        tabIndex={props.disabled ? -1 : 0}
+        role="button"
+        aria-label={props.ariaLabel ?? "Edit"}
+        aria-disabled={props.disabled ? "true" : undefined}
+        onClick={enterEdit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            enterEdit();
+          }
+        }}
+      >
+        {isEmpty && props.placeholder ? (
+          <span class={classes["placeholder"]}>{props.placeholder}</span>
+        ) : (
+          rendered
+        )}
+      </div>
+    );
+  }
+
+  const common = {
+    class: `${classes["edit"]} ${classes["root"]}`,
+    "data-polly-ui": true,
+    "data-polly-action-input": true,
+    "data-state": "editing",
+    "data-variant": variant,
+    placeholder: props.placeholder,
+    value: draft,
+    onInput: (
+      e: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setDraft(e.currentTarget.value),
+    onBlur: () => {
+      if (saveOn === "blur") commit(draft);
+      else cancel();
+    },
+    onKeyDown,
+    "aria-label": props.ariaLabel ?? "Edit",
+    disabled: props.disabled,
+  };
+
+  if (variant === "multi") {
+    return (
+      <textarea
+        ref={(el) => {
+          inputRef.current = el;
+        }}
+        {...(common as unknown as JSX.HTMLAttributes<HTMLTextAreaElement>)}
+      />
+    );
+  }
+  return (
+    <input
+      ref={(el) => {
+        inputRef.current = el;
+      }}
+      type="text"
+      {...(common as unknown as JSX.HTMLAttributes<HTMLInputElement>)}
+    />
+  );
+}

--- a/src/polly-ui/ConfirmDialog.module.css
+++ b/src/polly-ui/ConfirmDialog.module.css
@@ -1,0 +1,47 @@
+@layer polly-components {
+  .actions {
+    display: grid; /* layout-ignore */
+    grid-auto-flow: column;
+    gap: var(--polly-space-sm);
+    justify-content: end;
+  }
+
+  .cancel,
+  .confirm,
+  .confirmDanger {
+    appearance: none;
+    padding: var(--polly-space-sm) var(--polly-space-lg);
+    font: inherit;
+    font-weight: var(--polly-weight-medium);
+    border: var(--polly-border-width-default) solid var(--polly-border);
+    border-radius: var(--polly-radius-md);
+    cursor: pointer;
+    transition: background var(--polly-motion-fast) ease;
+  }
+
+  .cancel {
+    background: var(--polly-surface);
+    color: var(--polly-text);
+  }
+  .cancel:hover {
+    background: var(--polly-surface-sunken);
+  }
+
+  .confirm {
+    background: var(--polly-accent);
+    color: var(--polly-accent-contrast);
+    border-color: var(--polly-accent);
+  }
+  .confirm:hover {
+    filter: brightness(1.05);
+  }
+
+  .confirmDanger {
+    background: var(--polly-danger);
+    color: var(--polly-danger-contrast);
+    border-color: var(--polly-danger);
+  }
+  .confirmDanger:hover {
+    filter: brightness(1.05);
+  }
+}

--- a/src/polly-ui/ConfirmDialog.tsx
+++ b/src/polly-ui/ConfirmDialog.tsx
@@ -9,8 +9,8 @@
 
 import { signal } from "@preact/signals";
 import type { JSX } from "preact";
-import { Modal } from "./Modal.tsx";
 import classes from "./ConfirmDialog.module.css";
+import { Modal } from "./Modal.tsx";
 
 type ConfirmRequest = {
   id: number;

--- a/src/polly-ui/ConfirmDialog.tsx
+++ b/src/polly-ui/ConfirmDialog.tsx
@@ -1,0 +1,102 @@
+/**
+ * ConfirmDialog — Promise-returning confirmation primitive.
+ *
+ * `confirm({ title, body, danger })` returns Promise<boolean>. Opens the
+ * rendered `<ConfirmDialog.Host />` modal (which must be mounted once at
+ * the app root). User picking confirm or cancel resolves the promise.
+ * Escape, backdrop click, and explicit `.dismiss()` resolve false.
+ */
+
+import { signal } from "@preact/signals";
+import type { JSX } from "preact";
+import { Modal } from "./Modal.tsx";
+import classes from "./ConfirmDialog.module.css";
+
+type ConfirmRequest = {
+  id: number;
+  title: string;
+  body?: string;
+  danger?: boolean;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  resolve: (value: boolean) => void;
+};
+
+const pending = signal<ConfirmRequest | null>(null);
+const isOpen = signal(false);
+let nextId = 0;
+
+export type ConfirmOptions = {
+  title: string;
+  body?: string;
+  danger?: boolean;
+  confirmLabel?: string;
+  cancelLabel?: string;
+};
+
+export function confirm(options: ConfirmOptions): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    nextId += 1;
+    pending.value = {
+      id: nextId,
+      title: options.title,
+      body: options.body,
+      danger: options.danger,
+      confirmLabel: options.confirmLabel,
+      cancelLabel: options.cancelLabel,
+      resolve,
+    };
+    isOpen.value = true;
+  });
+}
+
+function close(result: boolean): void {
+  const current = pending.value;
+  if (!current) return;
+  isOpen.value = false;
+  pending.value = null;
+  current.resolve(result);
+}
+
+/** Renders the active confirm dialog. Mount once near the app root. */
+function Host(): JSX.Element | null {
+  const current = pending.value;
+  if (!current) return null;
+  return (
+    <Modal.Root when={isOpen} onClose={() => close(false)}>
+      <Modal.Backdrop />
+      <Modal.Content>
+        <Modal.Header>
+          <Modal.Title>{current.title}</Modal.Title>
+        </Modal.Header>
+        {current.body ? <Modal.Body>{current.body}</Modal.Body> : null}
+        <Modal.Footer>
+          <div class={classes["actions"]} data-polly-confirm-actions>
+            <button
+              type="button"
+              class={classes["cancel"]}
+              data-polly-ui
+              data-polly-interactive
+              data-polly-confirm-cancel
+              onClick={() => close(false)}
+            >
+              {current.cancelLabel ?? "Cancel"}
+            </button>
+            <button
+              type="button"
+              class={current.danger ? classes["confirmDanger"] : classes["confirm"]}
+              data-polly-ui
+              data-polly-interactive
+              data-polly-confirm-ok
+              onClick={() => close(true)}
+            >
+              {current.confirmLabel ?? "OK"}
+            </button>
+          </div>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+export const ConfirmDialog = { Host, confirm };

--- a/src/polly-ui/Layout.module.css
+++ b/src/polly-ui/Layout.module.css
@@ -1,0 +1,48 @@
+@layer polly-components {
+  .layout {
+    /* Reset so nested Layouts don't inherit ancestor tokens. */
+    --l-cols: none;
+    --l-rows: none;
+    --l-gap: 0;
+    --l-p: 0;
+    --l-h: auto;
+    --l-mh: auto;
+    --l-ji: stretch;
+    --l-ai: start;
+    --l-jc: normal;
+    --l-ac: normal;
+    --l-js: auto;
+    --l-as: auto;
+    --l-flow: row;
+    --l-arows: auto;
+    --l-acols: auto;
+    --l-col: auto;
+
+    display: grid;
+    inline-size: 100%;
+    grid-template-columns: var(--l-cols);
+    grid-template-rows: var(--l-rows);
+    gap: var(--l-gap);
+    padding: var(--l-p);
+    height: var(--l-h);
+    min-height: var(--l-mh);
+    justify-items: var(--l-ji);
+    align-items: var(--l-ai);
+    justify-content: var(--l-jc);
+    align-content: var(--l-ac);
+    justify-self: var(--l-js);
+    align-self: var(--l-as);
+    grid-auto-flow: var(--l-flow);
+    grid-auto-rows: var(--l-arows);
+    grid-auto-columns: var(--l-acols);
+    grid-column: var(--l-col);
+  }
+
+  @media (max-width: 640px) {
+    .stackOnMobile {
+      grid-template-columns: 1fr;
+      grid-auto-flow: row;
+      grid-column: auto;
+    }
+  }
+}

--- a/src/polly-ui/Layout.tsx
+++ b/src/polly-ui/Layout.tsx
@@ -8,11 +8,7 @@
  * any of them in media queries without touching specificity.
  */
 
-import {
-  type ComponentChildren,
-  createElement,
-  type JSX,
-} from "preact";
+import { type ComponentChildren, createElement, type JSX } from "preact";
 import classes from "./Layout.module.css";
 
 export type LayoutProps = {
@@ -66,6 +62,7 @@ export type LayoutProps = {
   "aria-describedby"?: string;
 };
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sixteen optional prop-to-custom-property mappings; flat and linear.
 export function Layout(props: LayoutProps): JSX.Element {
   const {
     children,
@@ -127,11 +124,7 @@ export function Layout(props: LayoutProps): JSX.Element {
   const baseClass = stackOnMobile
     ? `${classes["layout"]} ${classes["stackOnMobile"]}`
     : classes["layout"];
-  const combined = contents
-    ? className
-    : className
-      ? `${baseClass} ${className}`
-      : baseClass;
+  const combined = contents ? className : className ? `${baseClass} ${className}` : baseClass;
 
   return createElement(
     as,
@@ -148,6 +141,6 @@ export function Layout(props: LayoutProps): JSX.Element {
       "aria-describedby": props["aria-describedby"],
       "data-polly-layout": true,
     },
-    children,
+    children
   );
 }

--- a/src/polly-ui/Layout.tsx
+++ b/src/polly-ui/Layout.tsx
@@ -1,0 +1,153 @@
+/**
+ * Layout — the one primitive that owns layouting concerns.
+ *
+ * Every other component in @fairfox/polly/ui (and every consumer app
+ * that runs `polly quality css-layout`) routes flex/grid decisions
+ * through this component. Props map to CSS custom properties so the
+ * stylesheet can read them uniformly and so consumers can override
+ * any of them in media queries without touching specificity.
+ */
+
+import {
+  type ComponentChildren,
+  createElement,
+  type JSX,
+} from "preact";
+import classes from "./Layout.module.css";
+
+export type LayoutProps = {
+  children: ComponentChildren;
+
+  /** Polymorphic element (div, section, header, nav, …). Defaults to 'div'. */
+  as?: keyof JSX.IntrinsicElements;
+
+  /** CSS grid structure. */
+  rows?: string;
+  columns?: string;
+  autoFlow?: string;
+  autoRows?: string;
+  autoColumns?: string;
+
+  /** display: contents — lets children participate in an ancestor grid. */
+  contents?: boolean;
+  /** Inherit parent grid tracks via CSS subgrid. */
+  subgrid?: boolean;
+
+  /** Spacing. */
+  gap?: string;
+  padding?: string;
+
+  /** Sizing. */
+  height?: string;
+  minHeight?: string;
+
+  /** Container alignment. */
+  justifyItems?: string;
+  alignItems?: string;
+  justifyContent?: string;
+  alignContent?: string;
+
+  /** Self alignment (when this Layout is an item in a parent grid). */
+  justifySelf?: string;
+  alignSelf?: string;
+
+  /** Collapse to a single column at ≤640px. */
+  stackOnMobile?: boolean;
+
+  className?: string;
+  onClick?: JSX.MouseEventHandler<HTMLElement>;
+  onKeyDown?: JSX.KeyboardEventHandler<HTMLElement>;
+
+  role?: JSX.AriaRole;
+  tabIndex?: number;
+  id?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+};
+
+export function Layout(props: LayoutProps): JSX.Element {
+  const {
+    children,
+    as = "div",
+    rows,
+    columns,
+    contents,
+    subgrid,
+    gap,
+    padding,
+    height,
+    minHeight,
+    justifyItems,
+    alignItems,
+    justifyContent,
+    alignContent,
+    justifySelf,
+    alignSelf,
+    autoFlow,
+    autoRows,
+    autoColumns,
+    stackOnMobile,
+    className,
+    onClick,
+    onKeyDown,
+    role,
+    tabIndex,
+    id,
+  } = props;
+
+  const style: Record<string, string> = {};
+
+  if (contents) {
+    style["display"] = "contents";
+  } else if (subgrid) {
+    style["--l-col"] = "1 / -1";
+    style["--l-cols"] = "subgrid";
+    if (padding) style["--l-p"] = padding;
+    if (alignItems) style["--l-ai"] = alignItems;
+    if (gap) style["--l-gap"] = gap;
+  } else {
+    if (padding) style["--l-p"] = padding;
+    if (height) style["--l-h"] = height;
+    if (minHeight) style["--l-mh"] = minHeight;
+    if (rows) style["--l-rows"] = rows;
+    if (columns) style["--l-cols"] = columns;
+    if (gap) style["--l-gap"] = gap;
+    if (justifyItems) style["--l-ji"] = justifyItems;
+    if (alignItems) style["--l-ai"] = alignItems;
+    if (justifyContent) style["--l-jc"] = justifyContent;
+    if (alignContent) style["--l-ac"] = alignContent;
+    if (autoFlow) style["--l-flow"] = autoFlow;
+    if (autoRows) style["--l-arows"] = autoRows;
+    if (autoColumns) style["--l-acols"] = autoColumns;
+  }
+  if (justifySelf) style["--l-js"] = justifySelf;
+  if (alignSelf) style["--l-as"] = alignSelf;
+
+  const baseClass = stackOnMobile
+    ? `${classes["layout"]} ${classes["stackOnMobile"]}`
+    : classes["layout"];
+  const combined = contents
+    ? className
+    : className
+      ? `${baseClass} ${className}`
+      : baseClass;
+
+  return createElement(
+    as,
+    {
+      id,
+      className: combined,
+      style,
+      onClick,
+      onKeyDown,
+      role,
+      tabIndex,
+      "aria-label": props["aria-label"],
+      "aria-labelledby": props["aria-labelledby"],
+      "aria-describedby": props["aria-describedby"],
+      "data-polly-layout": true,
+    },
+    children,
+  );
+}

--- a/src/polly-ui/Modal.module.css
+++ b/src/polly-ui/Modal.module.css
@@ -1,0 +1,69 @@
+@layer polly-components {
+  .container {
+    position: fixed;
+    inset: 0;
+    display: grid; /* layout-ignore */
+    place-items: center;
+    pointer-events: none;
+  }
+
+  .backdrop {
+    position: absolute;
+    inset: 0;
+    background: color-mix(in srgb, var(--polly-text) 50%, transparent);
+    pointer-events: auto;
+  }
+
+  .surface {
+    position: relative;
+    pointer-events: auto;
+    background: var(--polly-surface-raised);
+    color: var(--polly-text);
+    border: var(--polly-border-width-default) solid var(--polly-border);
+    border-radius: var(--polly-radius-lg);
+    box-shadow: var(--polly-shadow-lg);
+    max-inline-size: min(640px, calc(100vw - 2 * var(--polly-space-lg)));
+    max-block-size: calc(100vh - 2 * var(--polly-space-lg));
+    overflow: auto;
+  }
+
+  .header {
+    padding: var(--polly-space-lg);
+    border-block-end: var(--polly-border-width-default) solid
+      var(--polly-border);
+  }
+
+  .title {
+    margin: 0;
+    font-size: var(--polly-text-xl);
+    font-weight: var(--polly-weight-bold);
+    line-height: var(--polly-line-height-tight);
+  }
+
+  .body {
+    padding: var(--polly-space-lg);
+  }
+
+  .footer {
+    padding: var(--polly-space-lg);
+    border-block-start: var(--polly-border-width-default) solid
+      var(--polly-border);
+  }
+
+  .close {
+    appearance: none;
+    background: transparent;
+    color: var(--polly-text);
+    border: var(--polly-border-width-default) solid transparent;
+    border-radius: var(--polly-radius-md);
+    padding: var(--polly-space-sm) var(--polly-space-md);
+    font: inherit;
+    cursor: pointer;
+    transition: background var(--polly-motion-fast) ease,
+      border-color var(--polly-motion-fast) ease;
+  }
+  .close:hover {
+    background: var(--polly-surface-sunken);
+    border-color: var(--polly-border);
+  }
+}

--- a/src/polly-ui/Modal.tsx
+++ b/src/polly-ui/Modal.tsx
@@ -1,0 +1,205 @@
+/**
+ * Modal — compound dialog with focus trap, Escape handling, portal,
+ * and overlay-stack integration.
+ *
+ * Root takes a `when` signal (or boolean). When truthy the content mounts
+ * into the OverlayRoot portal, focus moves inside, Tab is trapped, Escape
+ * fires `data-action="modal:close"` (or the overlay registry's onClose
+ * callback), and the body scroll locks.
+ */
+
+import type { ReadonlySignal } from "@preact/signals";
+import { type ComponentChildren, createContext } from "preact";
+import { createPortal } from "preact/compat";
+import { useContext, useEffect, useId, useRef, useState } from "preact/hooks";
+import {
+  popOverlay,
+  pushOverlay,
+} from "../actions/overlay.ts";
+import { installFocusTrap } from "./internal/focus-trap.ts";
+import classes from "./Modal.module.css";
+import { getOverlayRootNode } from "./OverlayRoot.tsx";
+
+type ModalContext = {
+  id: string;
+  titleId: string;
+  descId: string;
+  close: () => void;
+};
+
+const Ctx = createContext<ModalContext | null>(null);
+
+function useModal(): ModalContext {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error("Modal sub-components must render inside <Modal.Root>");
+  return ctx;
+}
+
+type RootProps = {
+  when: ReadonlySignal<boolean> | boolean;
+  onClose?: () => void;
+  children: ComponentChildren;
+  /** Accessible label source: "title" uses the <Modal.Title> id, or pass an explicit label. */
+  "aria-label"?: string;
+};
+
+function Root({ when, onClose, children, "aria-label": ariaLabel }: RootProps) {
+  const id = useId();
+  const titleId = `${id}-title`;
+  const descId = `${id}-desc`;
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const [portalNode, setPortalNode] = useState<HTMLElement | null>(null);
+
+  const isOpen = typeof when === "boolean" ? when : when.value;
+
+  useEffect(() => {
+    if (!isOpen) {
+      setPortalNode(null);
+      return;
+    }
+    setPortalNode(getOverlayRootNode());
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !portalNode) return;
+    const entry = { id, onClose };
+    pushOverlay(entry);
+    const el = mountRef.current;
+    const cleanup = el ? installFocusTrap(el) : () => {};
+    return () => {
+      cleanup();
+      popOverlay(id);
+    };
+  }, [isOpen, portalNode, id, onClose]);
+
+  if (!isOpen || !portalNode) return null;
+
+  const close = () => {
+    onClose?.();
+  };
+
+  const ctx: ModalContext = { id, titleId, descId, close };
+
+  const content = (
+    <Ctx.Provider value={ctx}>
+      <div
+        ref={mountRef}
+        class={classes["container"]}
+        data-polly-ui
+        data-polly-modal-content
+        data-overlay-id={id}
+        data-state="open"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={ariaLabel ? undefined : titleId}
+        aria-label={ariaLabel}
+        aria-describedby={descId}
+      >
+        {children}
+      </div>
+    </Ctx.Provider>
+  );
+
+  return createPortal(content, portalNode);
+}
+
+function Backdrop() {
+  const { close } = useModal();
+  return (
+    <div
+      class={classes["backdrop"]}
+      data-polly-modal-backdrop
+      onClick={close}
+      aria-hidden="true"
+    />
+  );
+}
+
+function Content({ children }: { children: ComponentChildren }) {
+  return (
+    <div class={classes["surface"]} data-polly-modal-surface>
+      {children}
+    </div>
+  );
+}
+
+function Header({ children }: { children: ComponentChildren }) {
+  return (
+    <header class={classes["header"]} data-polly-modal-header>
+      {children}
+    </header>
+  );
+}
+
+function Title({ children }: { children: ComponentChildren }) {
+  const { titleId } = useModal();
+  return (
+    <h2 id={titleId} class={classes["title"]} data-polly-modal-title>
+      {children}
+    </h2>
+  );
+}
+
+function Body({ children }: { children: ComponentChildren }) {
+  const { descId } = useModal();
+  return (
+    <div id={descId} class={classes["body"]} data-polly-modal-body>
+      {children}
+    </div>
+  );
+}
+
+function Footer({ children }: { children: ComponentChildren }) {
+  return (
+    <footer class={classes["footer"]} data-polly-modal-footer>
+      {children}
+    </footer>
+  );
+}
+
+type CloseProps = {
+  children: ComponentChildren;
+  /** Fire a registered data-action instead of calling the onClose callback. */
+  action?: string;
+};
+
+function Close({ children, action }: CloseProps) {
+  const { close } = useModal();
+  if (action) {
+    return (
+      <button
+        type="button"
+        class={classes["close"]}
+        data-polly-ui
+        data-polly-interactive
+        data-polly-modal-close
+        data-action={action}
+      >
+        {children}
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      class={classes["close"]}
+      data-polly-ui
+      data-polly-interactive
+      data-polly-modal-close
+      onClick={close}
+    >
+      {children}
+    </button>
+  );
+}
+
+export const Modal = {
+  Root,
+  Backdrop,
+  Content,
+  Header,
+  Title,
+  Body,
+  Footer,
+  Close,
+};

--- a/src/polly-ui/Modal.tsx
+++ b/src/polly-ui/Modal.tsx
@@ -12,10 +12,7 @@ import type { ReadonlySignal } from "@preact/signals";
 import { type ComponentChildren, createContext } from "preact";
 import { createPortal } from "preact/compat";
 import { useContext, useEffect, useId, useRef, useState } from "preact/hooks";
-import {
-  popOverlay,
-  pushOverlay,
-} from "../actions/overlay.ts";
+import { popOverlay, pushOverlay } from "../actions/overlay.ts";
 import { installFocusTrap } from "./internal/focus-trap.ts";
 import classes from "./Modal.module.css";
 import { getOverlayRootNode } from "./OverlayRoot.tsx";
@@ -65,7 +62,11 @@ function Root({ when, onClose, children, "aria-label": ariaLabel }: RootProps) {
     const entry = { id, onClose };
     pushOverlay(entry);
     const el = mountRef.current;
-    const cleanup = el ? installFocusTrap(el) : () => {};
+    const cleanup = el
+      ? installFocusTrap(el)
+      : () => {
+          /* no ref yet */
+        };
     return () => {
       cleanup();
       popOverlay(id);
@@ -106,12 +107,7 @@ function Root({ when, onClose, children, "aria-label": ariaLabel }: RootProps) {
 function Backdrop() {
   const { close } = useModal();
   return (
-    <div
-      class={classes["backdrop"]}
-      data-polly-modal-backdrop
-      onClick={close}
-      aria-hidden="true"
-    />
+    <div class={classes["backdrop"]} data-polly-modal-backdrop onClick={close} aria-hidden="true" />
   );
 }
 

--- a/src/polly-ui/OverlayRoot.module.css
+++ b/src/polly-ui/OverlayRoot.module.css
@@ -1,0 +1,7 @@
+@layer polly-components {
+  .root {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+  }
+}

--- a/src/polly-ui/OverlayRoot.tsx
+++ b/src/polly-ui/OverlayRoot.tsx
@@ -31,14 +31,7 @@ export function OverlayRoot() {
     };
   }, []);
 
-  return (
-    <div
-      ref={ref}
-      class={classes["root"]}
-      data-polly-ui
-      data-polly-overlay-root
-    />
-  );
+  return <div ref={ref} class={classes["root"]} data-polly-ui data-polly-overlay-root />;
 }
 
 /** Get the mount node for portaled overlays. Returns null before mount. */

--- a/src/polly-ui/OverlayRoot.tsx
+++ b/src/polly-ui/OverlayRoot.tsx
@@ -1,0 +1,47 @@
+/**
+ * OverlayRoot — portal target for stacked overlays.
+ *
+ * Apps render <OverlayRoot /> once, typically as the last child of the
+ * app root. Modal, ConfirmDialog, and Toast portal into this element;
+ * the scroll lock toggles based on the overlay registry count.
+ */
+
+import { effect } from "@preact/signals";
+import { useEffect, useRef } from "preact/hooks";
+import { hasOpenOverlay } from "../actions/overlay.ts";
+import { acquireScrollLock } from "./internal/scroll-lock.ts";
+import classes from "./OverlayRoot.module.css";
+
+export function OverlayRoot() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let release: (() => void) | null = null;
+    const dispose = effect(() => {
+      if (hasOpenOverlay()) {
+        if (!release) release = acquireScrollLock();
+      } else if (release) {
+        release();
+        release = null;
+      }
+    });
+    return () => {
+      dispose();
+      release?.();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      class={classes["root"]}
+      data-polly-ui
+      data-polly-overlay-root
+    />
+  );
+}
+
+/** Get the mount node for portaled overlays. Returns null before mount. */
+export function getOverlayRootNode(): HTMLElement | null {
+  return document.querySelector<HTMLElement>("[data-polly-overlay-root]");
+}

--- a/src/polly-ui/TextInput.module.css
+++ b/src/polly-ui/TextInput.module.css
@@ -1,0 +1,37 @@
+@layer polly-components {
+  .input {
+    inline-size: 100%;
+    box-sizing: border-box;
+    padding: var(--polly-space-sm) var(--polly-space-md);
+    font: inherit;
+    font-family: var(--polly-font-sans);
+    color: var(--polly-text);
+    background: var(--polly-surface);
+    border: var(--polly-border-width-default) solid var(--polly-border);
+    border-radius: var(--polly-radius-md);
+    transition: border-color var(--polly-motion-fast) ease,
+      background var(--polly-motion-fast) ease;
+  }
+
+  .input:hover {
+    border-color: var(--polly-border-strong);
+  }
+
+  .input[data-state="invalid"] {
+    border-color: var(--polly-danger);
+  }
+
+  .input:disabled {
+    opacity: var(--polly-opacity-disabled);
+    cursor: not-allowed;
+  }
+
+  .input[data-polly-input-variant="multi"] {
+    field-sizing: content;
+    min-block-size: calc(
+      1.5em + 2 * var(--polly-space-sm) + 2 * var(--polly-border-width-default)
+    );
+    max-block-size: 40em;
+    resize: vertical;
+  }
+}

--- a/src/polly-ui/TextInput.tsx
+++ b/src/polly-ui/TextInput.tsx
@@ -1,0 +1,101 @@
+/**
+ * TextInput — passive, signal-friendly native input wrapper.
+ *
+ * Designed to live inside <ActionForm>. Pass a plain string for
+ * uncontrolled mode (FormData-on-submit picks up the value) or a
+ * Signal<string> for controlled mode. Either way, a11y attributes are
+ * wired by the shared input-base, the stable `[data-polly-input]` hook
+ * is applied for styling, and `invalid` flips `aria-invalid` and
+ * `data-state="invalid"` for consumer selectors.
+ */
+
+import type { Signal } from "@preact/signals";
+import type { JSX } from "preact";
+import { buildInputA11y } from "./internal/input-base.ts";
+import classes from "./TextInput.module.css";
+
+type Variant = "single" | "multi";
+
+export type TextInputProps = {
+  name: string;
+  /** Signal<string> for controlled, string for uncontrolled default. */
+  value?: Signal<string> | string;
+  variant?: Variant;
+  placeholder?: string;
+  invalid?: boolean;
+  required?: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
+  id?: string;
+  describedBy?: string;
+  rows?: number;
+  autoFocus?: boolean;
+  className?: string;
+};
+
+function isSignal<T>(v: Signal<T> | T | undefined): v is Signal<T> {
+  return typeof v === "object" && v !== null && "value" in v && "peek" in (v as object);
+}
+
+export function TextInput(props: TextInputProps): JSX.Element {
+  const variant = props.variant ?? "single";
+  const a11y = buildInputA11y({
+    name: props.name,
+    id: props.id,
+    required: props.required,
+    invalid: props.invalid,
+    describedBy: props.describedBy,
+    placeholder: props.placeholder,
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  });
+
+  const controlled = isSignal(props.value);
+  const stringValue = controlled
+    ? (props.value as Signal<string>).value
+    : undefined;
+  const defaultValue = controlled
+    ? undefined
+    : (props.value as string | undefined) ?? "";
+
+  const className = props.className
+    ? `${classes["input"]} ${props.className}`
+    : classes["input"];
+
+  if (variant === "multi") {
+    return (
+      <textarea
+        {...(a11y as unknown as JSX.HTMLAttributes<HTMLTextAreaElement>)}
+        class={className}
+        data-polly-input-variant="multi"
+        rows={props.rows}
+        autoFocus={props.autoFocus}
+        value={stringValue}
+        defaultValue={defaultValue}
+        onInput={(e) => {
+          if (controlled) {
+            (props.value as Signal<string>).value =
+              e.currentTarget.value;
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <input
+      {...(a11y as unknown as JSX.HTMLAttributes<HTMLInputElement>)}
+      type="text"
+      class={className}
+      data-polly-input-variant="single"
+      autoFocus={props.autoFocus}
+      value={stringValue}
+      defaultValue={defaultValue}
+      onInput={(e) => {
+        if (controlled) {
+          (props.value as Signal<string>).value = e.currentTarget.value;
+        }
+      }}
+    />
+  );
+}

--- a/src/polly-ui/TextInput.tsx
+++ b/src/polly-ui/TextInput.tsx
@@ -51,16 +51,10 @@ export function TextInput(props: TextInputProps): JSX.Element {
   });
 
   const controlled = isSignal(props.value);
-  const stringValue = controlled
-    ? (props.value as Signal<string>).value
-    : undefined;
-  const defaultValue = controlled
-    ? undefined
-    : (props.value as string | undefined) ?? "";
+  const stringValue = controlled ? (props.value as Signal<string>).value : undefined;
+  const defaultValue = controlled ? undefined : ((props.value as string | undefined) ?? "");
 
-  const className = props.className
-    ? `${classes["input"]} ${props.className}`
-    : classes["input"];
+  const className = props.className ? `${classes["input"]} ${props.className}` : classes["input"];
 
   if (variant === "multi") {
     return (
@@ -69,13 +63,13 @@ export function TextInput(props: TextInputProps): JSX.Element {
         class={className}
         data-polly-input-variant="multi"
         rows={props.rows}
+        // biome-ignore lint/a11y/noAutofocus: opt-in prop — caller requests autofocus explicitly (e.g. form opens to this field).
         autoFocus={props.autoFocus}
         value={stringValue}
         defaultValue={defaultValue}
         onInput={(e) => {
           if (controlled) {
-            (props.value as Signal<string>).value =
-              e.currentTarget.value;
+            (props.value as Signal<string>).value = e.currentTarget.value;
           }
         }}
       />
@@ -88,6 +82,7 @@ export function TextInput(props: TextInputProps): JSX.Element {
       type="text"
       class={className}
       data-polly-input-variant="single"
+      // biome-ignore lint/a11y/noAutofocus: opt-in prop — caller requests autofocus explicitly (e.g. form opens to this field).
       autoFocus={props.autoFocus}
       value={stringValue}
       defaultValue={defaultValue}

--- a/src/polly-ui/Toast.module.css
+++ b/src/polly-ui/Toast.module.css
@@ -1,0 +1,47 @@
+@layer polly-components {
+  .viewport {
+    display: grid; /* layout-ignore */
+    gap: var(--polly-space-sm);
+  }
+
+  .item {
+    display: grid; /* layout-ignore */
+    grid-template-columns: 1fr auto;
+    gap: var(--polly-space-md);
+    align-items: center;
+    padding: var(--polly-space-md) var(--polly-space-lg);
+    background: var(--polly-surface-raised);
+    color: var(--polly-text);
+    border: var(--polly-border-width-default) solid var(--polly-border);
+    border-radius: var(--polly-radius-md);
+    box-shadow: var(--polly-shadow-md);
+    min-inline-size: 16em;
+    max-inline-size: 28em;
+  }
+
+  .item[data-severity="error"] {
+    border-color: var(--polly-danger);
+  }
+  .item[data-severity="warning"] {
+    border-color: var(--polly-warning);
+  }
+
+  .message {
+    font-size: var(--polly-text-md);
+    line-height: var(--polly-line-height-base);
+  }
+
+  .close {
+    appearance: none;
+    background: transparent;
+    color: inherit;
+    border: var(--polly-border-width-default) solid transparent;
+    border-radius: var(--polly-radius-sm);
+    padding: var(--polly-space-xs) var(--polly-space-sm);
+    font: inherit;
+    cursor: pointer;
+  }
+  .close:hover {
+    background: var(--polly-surface-sunken);
+  }
+}

--- a/src/polly-ui/Toast.tsx
+++ b/src/polly-ui/Toast.tsx
@@ -11,11 +11,7 @@
 import type { JSX } from "preact";
 import { createPortal } from "preact/compat";
 import { useEffect, useRef, useState } from "preact/hooks";
-import {
-  clearError,
-  type ErrorEntry,
-  errorState,
-} from "../actions/error.ts";
+import { clearError, type ErrorEntry, errorState } from "../actions/error.ts";
 import { getOverlayRootNode } from "./OverlayRoot.tsx";
 import classes from "./Toast.module.css";
 
@@ -47,6 +43,7 @@ function Viewport(props: ToastViewportProps): JSX.Element | null {
   if (!portalNode) return null;
 
   const content = (
+    // biome-ignore lint/a11y/noStaticElementInteractions: viewport pauses auto-dismiss on hover; it is a container, not an interactive control itself.
     <div
       class={`${classes["viewport"]} ${props.className ?? ""}`.trim()}
       data-polly-ui

--- a/src/polly-ui/Toast.tsx
+++ b/src/polly-ui/Toast.tsx
@@ -1,0 +1,94 @@
+/**
+ * Toast — consumer-facing surface for the global errorState.
+ *
+ * Renders every entry of the `errorState` signal into a viewport mounted
+ * inside OverlayRoot. `aria-live` is polite for info/warning and
+ * assertive for error severity. Each item auto-dismisses after
+ * `autoDismissMs` unless the user hovers the viewport. Clicking a
+ * toast or its close button removes that single entry.
+ */
+
+import type { JSX } from "preact";
+import { createPortal } from "preact/compat";
+import { useEffect, useRef, useState } from "preact/hooks";
+import {
+  clearError,
+  type ErrorEntry,
+  errorState,
+} from "../actions/error.ts";
+import { getOverlayRootNode } from "./OverlayRoot.tsx";
+import classes from "./Toast.module.css";
+
+export type ToastViewportProps = {
+  autoDismissMs?: number;
+  className?: string;
+};
+
+function Viewport(props: ToastViewportProps): JSX.Element | null {
+  const autoDismissMs = props.autoDismissMs ?? 5000;
+  const [portalNode, setPortalNode] = useState<HTMLElement | null>(null);
+  const [paused, setPaused] = useState(false);
+  const entries = errorState.value;
+
+  useEffect(() => {
+    setPortalNode(getOverlayRootNode());
+  }, []);
+
+  useEffect(() => {
+    if (paused || entries.length === 0) return;
+    const head = entries[0];
+    if (!head) return;
+    const timer = window.setTimeout(() => {
+      clearError(head.id);
+    }, autoDismissMs);
+    return () => window.clearTimeout(timer);
+  }, [paused, entries, autoDismissMs]);
+
+  if (!portalNode) return null;
+
+  const content = (
+    <div
+      class={`${classes["viewport"]} ${props.className ?? ""}`.trim()}
+      data-polly-ui
+      data-polly-toast-viewport
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+    >
+      {entries.map((entry) => (
+        <ToastItem key={entry.id} entry={entry} />
+      ))}
+    </div>
+  );
+  return createPortal(content, portalNode);
+}
+
+function ToastItem({ entry }: { entry: ErrorEntry }): JSX.Element {
+  const liveness = entry.severity === "error" ? "assertive" : "polite";
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={ref}
+      class={classes["item"]}
+      data-polly-ui
+      data-polly-toast-item
+      data-severity={entry.severity}
+      role={entry.severity === "error" ? "alert" : "status"}
+      aria-live={liveness}
+    >
+      <span class={classes["message"]}>{entry.message}</span>
+      <button
+        type="button"
+        class={classes["close"]}
+        data-polly-ui
+        data-polly-interactive
+        data-polly-toast-close
+        onClick={() => clearError(entry.id)}
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export const Toast = { Viewport };

--- a/src/polly-ui/css-modules.d.ts
+++ b/src/polly-ui/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.css" {
+  const classes: Record<string, string>;
+  export default classes;
+}

--- a/src/polly-ui/css-modules.d.ts
+++ b/src/polly-ui/css-modules.d.ts
@@ -1,4 +1,5 @@
 declare module "*.module.css" {
   const classes: Record<string, string>;
+  // biome-ignore lint/style/noDefaultExport: CSS-module imports are default-exported by convention.
   export default classes;
 }

--- a/src/polly-ui/index.ts
+++ b/src/polly-ui/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @fairfox/polly/ui — compound UI primitives.
+ *
+ * Every primitive is built on @fairfox/polly/actions: data-action hooks
+ * route events into the consumer's action registry, semantic tokens
+ * drive all visual values, and the <Layout> primitive owns every
+ * layouting concern. Ship styles.css and theme.css alongside to pick up
+ * the default look; redefine variables to re-theme.
+ */
+
+export { Layout, type LayoutProps } from "./Layout.tsx";
+export { Modal } from "./Modal.tsx";
+export { OverlayRoot, getOverlayRootNode } from "./OverlayRoot.tsx";
+export { TextInput, type TextInputProps } from "./TextInput.tsx";
+export {
+  ActionInput,
+  type ActionInputProps,
+  type ActionInputSaveOn,
+  type ActionInputVariant,
+} from "./ActionInput.tsx";
+export { ActionForm, type ActionFormProps } from "./ActionForm.tsx";
+export { Toast, type ToastViewportProps } from "./Toast.tsx";
+export { ConfirmDialog, type ConfirmOptions, confirm } from "./ConfirmDialog.tsx";

--- a/src/polly-ui/index.ts
+++ b/src/polly-ui/index.ts
@@ -8,16 +8,16 @@
  * the default look; redefine variables to re-theme.
  */
 
-export { Layout, type LayoutProps } from "./Layout.tsx";
-export { Modal } from "./Modal.tsx";
-export { OverlayRoot, getOverlayRootNode } from "./OverlayRoot.tsx";
-export { TextInput, type TextInputProps } from "./TextInput.tsx";
+export { ActionForm, type ActionFormProps } from "./ActionForm.tsx";
 export {
   ActionInput,
   type ActionInputProps,
   type ActionInputSaveOn,
   type ActionInputVariant,
 } from "./ActionInput.tsx";
-export { ActionForm, type ActionFormProps } from "./ActionForm.tsx";
-export { Toast, type ToastViewportProps } from "./Toast.tsx";
 export { ConfirmDialog, type ConfirmOptions, confirm } from "./ConfirmDialog.tsx";
+export { Layout, type LayoutProps } from "./Layout.tsx";
+export { Modal } from "./Modal.tsx";
+export { getOverlayRootNode, OverlayRoot } from "./OverlayRoot.tsx";
+export { TextInput, type TextInputProps } from "./TextInput.tsx";
+export { Toast, type ToastViewportProps } from "./Toast.tsx";

--- a/src/polly-ui/internal/focus-trap.ts
+++ b/src/polly-ui/internal/focus-trap.ts
@@ -23,20 +23,16 @@ const FOCUSABLE_SELECTOR = [
 ].join(",");
 
 function getFocusable(root: HTMLElement): HTMLElement[] {
-  const nodes = Array.from(
-    root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-  );
+  const nodes = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
   return nodes.filter(
-    (el) =>
-      !el.hasAttribute("disabled") &&
-      el.getAttribute("aria-hidden") !== "true",
+    (el) => !el.hasAttribute("disabled") && el.getAttribute("aria-hidden") !== "true"
   );
 }
 
 export function installFocusTrap(root: HTMLElement): () => void {
-  const previousActive = (document.activeElement instanceof HTMLElement
-    ? document.activeElement
-    : null) as HTMLElement | null;
+  const previousActive = (
+    document.activeElement instanceof HTMLElement ? document.activeElement : null
+  ) as HTMLElement | null;
 
   // Move focus into the root if it's not already.
   const focusable = getFocusable(root);
@@ -61,11 +57,9 @@ export function installFocusTrap(root: HTMLElement): () => void {
         event.preventDefault();
         lastItem.focus();
       }
-    } else {
-      if (active === lastItem) {
-        event.preventDefault();
-        firstItem.focus();
-      }
+    } else if (active === lastItem) {
+      event.preventDefault();
+      firstItem.focus();
     }
   }
 

--- a/src/polly-ui/internal/focus-trap.ts
+++ b/src/polly-ui/internal/focus-trap.ts
@@ -1,0 +1,80 @@
+/**
+ * Focus trap.
+ *
+ * Keeps Tab / Shift+Tab inside a root element. Returns a cleanup that
+ * restores focus to the element that was active before the trap mounted.
+ * Simple and synchronous — assumes a single active trap per OverlayRoot
+ * and lets the overlay registry in `@fairfox/polly/actions` enforce that
+ * at the stack level.
+ */
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type=hidden])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "iframe",
+  "object",
+  "embed",
+  '[tabindex]:not([tabindex="-1"])',
+  "[contenteditable]",
+].join(",");
+
+function getFocusable(root: HTMLElement): HTMLElement[] {
+  const nodes = Array.from(
+    root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  );
+  return nodes.filter(
+    (el) =>
+      !el.hasAttribute("disabled") &&
+      el.getAttribute("aria-hidden") !== "true",
+  );
+}
+
+export function installFocusTrap(root: HTMLElement): () => void {
+  const previousActive = (document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null) as HTMLElement | null;
+
+  // Move focus into the root if it's not already.
+  const focusable = getFocusable(root);
+  const first = focusable[0] ?? root;
+  if (!root.contains(document.activeElement)) {
+    first.focus();
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (event.key !== "Tab") return;
+    const items = getFocusable(root);
+    if (items.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const firstItem = items[0];
+    const lastItem = items[items.length - 1];
+    if (!firstItem || !lastItem) return;
+    const active = document.activeElement;
+    if (event.shiftKey) {
+      if (active === firstItem || !root.contains(active)) {
+        event.preventDefault();
+        lastItem.focus();
+      }
+    } else {
+      if (active === lastItem) {
+        event.preventDefault();
+        firstItem.focus();
+      }
+    }
+  }
+
+  document.addEventListener("keydown", handleKeyDown);
+
+  return () => {
+    document.removeEventListener("keydown", handleKeyDown);
+    if (previousActive && document.contains(previousActive)) {
+      previousActive.focus();
+    }
+  };
+}

--- a/src/polly-ui/internal/input-base.ts
+++ b/src/polly-ui/internal/input-base.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared input a11y wiring.
+ *
+ * Returns a common set of attributes that TextInput, ActionInput, and
+ * any consumer-built input can splat onto its native element. Keeps
+ * aria-* and data-polly-* names consistent across the family.
+ */
+
+export type InputA11yProps = {
+  name?: string;
+  id?: string;
+  required?: boolean;
+  invalid?: boolean;
+  describedBy?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+};
+
+export function buildInputA11y(props: InputA11yProps) {
+  const attrs: Record<string, unknown> = {
+    "data-polly-ui": true,
+    "data-polly-input": true,
+    "aria-invalid": props.invalid ? "true" : undefined,
+    "aria-required": props.required ? "true" : undefined,
+    "aria-describedby": props.describedBy,
+    name: props.name,
+    id: props.id,
+    placeholder: props.placeholder,
+    disabled: props.disabled,
+    readOnly: props.readOnly,
+  };
+  if (props.invalid) attrs["data-state"] = "invalid";
+  return attrs;
+}

--- a/src/polly-ui/internal/scroll-lock.ts
+++ b/src/polly-ui/internal/scroll-lock.ts
@@ -1,0 +1,32 @@
+/**
+ * Scroll lock.
+ *
+ * Reference-counted. Multiple overlays can request a lock; the body
+ * stays locked until every request releases. A scrollbar-gutter token
+ * is written at acquire time so content behind the overlay doesn't
+ * reflow when the bar disappears.
+ */
+
+let count = 0;
+
+export function acquireScrollLock(): () => void {
+  if (count === 0) {
+    const html = document.documentElement;
+    const gutter = window.innerWidth - html.clientWidth;
+    html.style.setProperty("--polly-scrollbar-gutter", `${gutter}px`);
+    html.setAttribute("data-polly-scroll-locked", "true");
+  }
+  count += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    count -= 1;
+    if (count <= 0) {
+      count = 0;
+      const html = document.documentElement;
+      html.removeAttribute("data-polly-scroll-locked");
+      html.style.removeProperty("--polly-scrollbar-gutter");
+    }
+  };
+}

--- a/src/polly-ui/styles.css
+++ b/src/polly-ui/styles.css
@@ -1,0 +1,70 @@
+/**
+ * @fairfox/polly/ui — structural + accessibility stylesheet.
+ *
+ * Not meant to be overridden. This file encodes the a11y guarantees of
+ * every primitive: minimum hit targets, focus-ring visibility, scroll
+ * lock when an overlay is open, motion zeroing under reduced-motion,
+ * and the stacking order for overlays and toasts. Consumers who want
+ * bespoke visuals override theme.css variables; they should not need
+ * to (and should not) change anything in here.
+ */
+
+@layer polly-structure {
+  /* Honour reduced-motion by zeroing every motion token. The components
+   * read only these tokens for their transitions, so a consumer preference
+   * of "reduce" makes every animation instant. */
+  @media (prefers-reduced-motion: reduce) {
+    :root {
+      --polly-motion-fast: 0ms;
+      --polly-motion-base: 0ms;
+      --polly-motion-slow: 0ms;
+    }
+  }
+
+  /* Focus ring — 2 pixels outside a 2 pixel offset. Not customisable past
+   * colour (via --polly-focus-ring); the shape is load-bearing for WCAG
+   * 2.4.11 "focus not obscured". */
+  [data-polly-ui] :focus-visible,
+  [data-polly-ui]:focus-visible {
+    outline: var(--polly-border-width-medium) solid var(--polly-focus-ring);
+    outline-offset: var(--polly-border-width-medium);
+  }
+
+  /* Minimum hit targets — 44×44 for any interactive element hooked by Polly.
+   * Consumers who need smaller targets inside compound components (icons in
+   * a toolbar, etc.) opt out via data-polly-hit-target="none". */
+  [data-polly-interactive]:not([data-polly-hit-target="none"]) {
+    min-inline-size: 44px;
+    min-block-size: 44px;
+  }
+
+  /* Scroll lock — toggled by OverlayRoot when the overlay stack is
+   * non-empty. The padding-right compensates for the scrollbar so content
+   * behind the overlay does not reflow. */
+  html[data-polly-scroll-locked="true"] {
+    overflow: hidden;
+    padding-inline-end: var(--polly-scrollbar-gutter, 0px);
+  }
+
+  /* Overlay layering. The stack is managed in JS; z-index values here
+   * only exist to guarantee ordering against application content. */
+  [data-polly-overlay-root] {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: var(--polly-z-overlay);
+  }
+  [data-polly-overlay-root] > * {
+    pointer-events: auto;
+  }
+  [data-polly-toast-viewport] {
+    position: fixed;
+    inset-block-end: var(--polly-space-lg);
+    inset-inline-end: var(--polly-space-lg);
+    z-index: var(--polly-z-toast);
+    pointer-events: none;
+  }
+  [data-polly-toast-viewport] > * {
+    pointer-events: auto;
+  }
+}

--- a/src/polly-ui/theme.css
+++ b/src/polly-ui/theme.css
@@ -1,0 +1,163 @@
+/**
+ * @fairfox/polly/ui — default theme.
+ *
+ * Semantic tokens only. Consumers redefine these variables to re-theme
+ * the primitives without touching structure or accessibility. Both the
+ * light palette (the :root defaults) and the dark palette (under
+ * prefers-color-scheme: dark) meet WCAG AA contrast against their
+ * respective surfaces — 4.5:1 for body text, 3:1 for non-text UI.
+ *
+ * Consumers can force a mode regardless of system preference by setting
+ * data-polly-theme="dark" or data-polly-theme="light" on any ancestor
+ * element (styles.css reads this and overrides prefers-color-scheme).
+ */
+
+@layer polly-defaults {
+  :root {
+    /* Surfaces */
+    --polly-surface: #ffffff;
+    --polly-surface-raised: #ffffff;
+    --polly-surface-sunken: #f4f5f7;
+
+    /* Borders */
+    --polly-border: #d9dbe0;
+    --polly-border-strong: #9fa3ab;
+
+    /* Text */
+    --polly-text: #111418;
+    --polly-text-muted: #5a5f67;
+
+    /* Accent */
+    --polly-accent: #2451b5;
+    --polly-accent-contrast: #ffffff;
+
+    /* Feedback */
+    --polly-danger: #b3261e;
+    --polly-danger-contrast: #ffffff;
+    --polly-success: #1f6f43;
+    --polly-warning: #8a5a00;
+
+    /* Focus */
+    --polly-focus-ring: #2451b5;
+
+    /* Space */
+    --polly-space-xs: 4px;
+    --polly-space-sm: 8px;
+    --polly-space-md: 12px;
+    --polly-space-lg: 16px;
+    --polly-space-xl: 24px;
+
+    /* Radius */
+    --polly-radius-sm: 4px;
+    --polly-radius-md: 8px;
+    --polly-radius-lg: 12px;
+
+    /* Motion */
+    --polly-motion-fast: 120ms;
+    --polly-motion-base: 200ms;
+    --polly-motion-slow: 320ms;
+
+    /* Typography */
+    --polly-font-sans: system-ui, -apple-system, "Segoe UI", Roboto,
+      "Helvetica Neue", Arial, sans-serif;
+    --polly-font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco,
+      "Cascadia Mono", monospace;
+    --polly-text-sm: 0.875em;
+    --polly-text-md: 1em;
+    --polly-text-lg: 1.125em;
+    --polly-text-xl: 1.375em;
+    --polly-weight-normal: 400;
+    --polly-weight-medium: 500;
+    --polly-weight-bold: 700;
+    --polly-line-height-tight: 1.25;
+    --polly-line-height-base: 1.5;
+
+    /* Z-index scale */
+    --polly-z-base: 0;
+    --polly-z-raised: 10;
+    --polly-z-overlay: 1000;
+    --polly-z-toast: 2000;
+
+    /* Opacity */
+    --polly-opacity-disabled: 0.55;
+
+    /* Border widths */
+    --polly-border-width-default: 1px;
+    --polly-border-width-medium: 2px;
+    --polly-border-width-thick: 4px;
+
+    /* Shadows */
+    --polly-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.06);
+    --polly-shadow-md: 0 4px 12px rgb(0 0 0 / 0.1);
+    --polly-shadow-lg: 0 12px 32px rgb(0 0 0 / 0.16);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --polly-surface: #14171c;
+      --polly-surface-raised: #1c2027;
+      --polly-surface-sunken: #0f1216;
+
+      --polly-border: #30353d;
+      --polly-border-strong: #5a6069;
+
+      --polly-text: #eef0f3;
+      --polly-text-muted: #a7adb5;
+
+      --polly-accent: #6c95ff;
+      --polly-accent-contrast: #0b1020;
+
+      --polly-danger: #ff8680;
+      --polly-danger-contrast: #0b1020;
+      --polly-success: #63c18a;
+      --polly-warning: #f2c269;
+
+      --polly-focus-ring: #6c95ff;
+
+      --polly-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.5);
+      --polly-shadow-md: 0 4px 12px rgb(0 0 0 / 0.6);
+      --polly-shadow-lg: 0 12px 32px rgb(0 0 0 / 0.7);
+    }
+  }
+
+  /* Explicit mode override — wins over prefers-color-scheme. */
+  [data-polly-theme="light"] {
+    --polly-surface: #ffffff;
+    --polly-surface-raised: #ffffff;
+    --polly-surface-sunken: #f4f5f7;
+    --polly-border: #d9dbe0;
+    --polly-border-strong: #9fa3ab;
+    --polly-text: #111418;
+    --polly-text-muted: #5a5f67;
+    --polly-accent: #2451b5;
+    --polly-accent-contrast: #ffffff;
+    --polly-danger: #b3261e;
+    --polly-danger-contrast: #ffffff;
+    --polly-success: #1f6f43;
+    --polly-warning: #8a5a00;
+    --polly-focus-ring: #2451b5;
+    --polly-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.06);
+    --polly-shadow-md: 0 4px 12px rgb(0 0 0 / 0.1);
+    --polly-shadow-lg: 0 12px 32px rgb(0 0 0 / 0.16);
+  }
+
+  [data-polly-theme="dark"] {
+    --polly-surface: #14171c;
+    --polly-surface-raised: #1c2027;
+    --polly-surface-sunken: #0f1216;
+    --polly-border: #30353d;
+    --polly-border-strong: #5a6069;
+    --polly-text: #eef0f3;
+    --polly-text-muted: #a7adb5;
+    --polly-accent: #6c95ff;
+    --polly-accent-contrast: #0b1020;
+    --polly-danger: #ff8680;
+    --polly-danger-contrast: #0b1020;
+    --polly-success: #63c18a;
+    --polly-warning: #f2c269;
+    --polly-focus-ring: #6c95ff;
+    --polly-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.5);
+    --polly-shadow-md: 0 4px 12px rgb(0 0 0 / 0.6);
+    --polly-shadow-lg: 0 12px 32px rgb(0 0 0 / 0.7);
+  }
+}

--- a/src/shared/lib/peer-repo-server.ts
+++ b/src/shared/lib/peer-repo-server.ts
@@ -35,15 +35,22 @@
  * ```
  */
 
-import { Repo } from "@automerge/automerge-repo/slim";
-import { WebSocketServerAdapter } from "@automerge/automerge-repo-network-websocket";
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
-import * as ws from "ws";
+// Heavy peer-relay dependencies (@automerge/automerge-repo, ws) are dynamic
+// imports loaded only when createPeerRepoServer is actually called. Static
+// imports at this file's top level were hoisted into @fairfox/polly/elysia's
+// module-init chain, breaking Elysia apps that don't use peer state and
+// don't install the automerge peer deps. Types come from the static package
+// references — TypeScript only reads them for shape, so no runtime cost is
+// incurred.
+import type { Repo as RepoType } from "@automerge/automerge-repo/slim";
+import type { WebSocketServerAdapter as WebSocketServerAdapterType } from "@automerge/automerge-repo-network-websocket";
+import type { NodeFSStorageAdapter as NodeFSStorageAdapterType } from "@automerge/automerge-repo-storage-nodefs";
+import type * as wsType from "ws";
 
 // `@types/ws` uses CJS `export = WebSocket` with WebSocketServer hanging off
 // the namespace. Under the project's bundler module resolution, the namespace
 // import gives us access to both the constructor and the type.
-type WebSocketServer = ws.WebSocketServer;
+type WebSocketServer = wsType.WebSocketServer;
 
 export interface CreatePeerRepoServerOptions {
   /** Port to listen on. The factory creates its own `WebSocketServer` and
@@ -64,14 +71,14 @@ export interface CreatePeerRepoServerOptions {
 export interface PeerRepoServer {
   /** A configured Repo participating as the always-on peer. Server-side
    * cron and HTTP handlers can open document handles on this directly. */
-  repo: Repo;
+  repo: RepoType;
   /** The underlying WebSocket server. Exposed for advanced use such as
    * health checks or graceful shutdown coordination. */
   webSocketServer: WebSocketServer;
   /** The Automerge network adapter wrapping the WebSocket server. */
-  adapter: WebSocketServerAdapter;
+  adapter: WebSocketServerAdapterType;
   /** The NodeFS storage adapter writing to {@link CreatePeerRepoServerOptions.storagePath}. */
-  storage: NodeFSStorageAdapter;
+  storage: NodeFSStorageAdapterType;
   /** Tear down the server: disconnect peers, flush storage, close the
    * underlying WebSocket server. Returns a promise that resolves once the
    * tear-down is complete. */
@@ -90,6 +97,17 @@ export interface PeerRepoServer {
 export async function createPeerRepoServer(
   options: CreatePeerRepoServerOptions
 ): Promise<PeerRepoServer> {
+  // Dynamic imports keep automerge-repo and ws out of the static module
+  // graph. Apps that never call this function — which is most of them —
+  // never pay the dependency cost and don't need the peer packages
+  // installed at all.
+  const [{ Repo }, { WebSocketServerAdapter }, { NodeFSStorageAdapter }, ws] = await Promise.all([
+    import("@automerge/automerge-repo/slim"),
+    import("@automerge/automerge-repo-network-websocket"),
+    import("@automerge/automerge-repo-storage-nodefs"),
+    import("ws"),
+  ]);
+
   // Construct the WebSocket server first and wait until it is actually
   // listening before wiring up the Repo. Using the constructor callback
   // avoids the race where the 'listening' event fires before our listener

--- a/tests/browser/actions/event-delegation.browser.ts
+++ b/tests/browser/actions/event-delegation.browser.ts
@@ -173,10 +173,8 @@ describe("installEventDelegation — keyboard", () => {
     );
     await flush();
 
-    // installEventDelegation's Escape path uses the DOM-based closeTopOverlay
-    // (dispatches `overlay:close` on the last [data-overlay-id] element).
-    // To also exercise the registry, we close via registry API directly:
-    closeTopOverlay();
+    // installEventDelegation's Escape path calls closeTopOverlay on the
+    // registry; 'b' is the top so its onClose fires and 'a' is preserved.
     expect(closedB).toBe(1);
     expect(closedA).toBe(0);
 

--- a/tests/browser/actions/event-delegation.browser.ts
+++ b/tests/browser/actions/event-delegation.browser.ts
@@ -1,0 +1,187 @@
+/**
+ * Browser test for event delegation end-to-end.
+ *
+ * Installs the document listener, plants DOM with `data-action`, fires
+ * click / submit / keyboard events, asserts handlers run with the right
+ * parsed data, the right element reference, and the form-click guard.
+ */
+
+import {
+  closeTopOverlay,
+  installEventDelegation,
+  pushOverlay,
+  resetOverlayStack,
+} from "../../../src/actions";
+import {
+  cleanup,
+  describe,
+  done,
+  expect,
+  flush,
+  test,
+} from "../../../tools/test/src/browser/harness";
+
+const root = document.getElementById("app") ?? document.body;
+
+function mount(html: string): HTMLElement {
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  root.appendChild(host);
+  return host;
+}
+
+describe("installEventDelegation — click events", () => {
+  test("fires the handler with parsed data-action-* camelCase", async () => {
+    let seen:
+      | { action: string; data: Record<string, string>; tag: string }
+      | undefined;
+    const off = installEventDelegation((d) => {
+      seen = { action: d.action, data: d.data, tag: d.element.tagName };
+    });
+
+    const host = mount(`
+      <button id="btn"
+              data-action="team:create"
+              data-action-team-id="42"
+              data-action-label="Alpha">Create</button>
+    `);
+    host.querySelector<HTMLButtonElement>("#btn")!.click();
+    await flush();
+
+    expect(seen?.action).toBe("team:create");
+    expect(seen?.data).toEqual({ teamId: "42", label: "Alpha" });
+    expect(seen?.tag).toBe("BUTTON");
+
+    off();
+    cleanup(host);
+  });
+
+  test("walks up to the nearest [data-action] ancestor", async () => {
+    let action: string | undefined;
+    const off = installEventDelegation((d) => {
+      action = d.action;
+    });
+
+    const host = mount(`
+      <button data-action="outer"><span id="inner">inner</span></button>
+    `);
+    host.querySelector<HTMLElement>("#inner")!.click();
+    await flush();
+    expect(action).toBe("outer");
+
+    off();
+    cleanup(host);
+  });
+
+  test("ignores clicks on <form data-action> (form fires on submit only)", async () => {
+    let clicks = 0;
+    const off = installEventDelegation(() => {
+      clicks += 1;
+    });
+
+    const host = mount(`
+      <form data-action="team:save">
+        <input name="name" />
+        <button type="button" id="inside">inside</button>
+      </form>
+    `);
+    host.querySelector<HTMLButtonElement>("#inside")!.click();
+    await flush();
+    expect(clicks).toBe(0);
+
+    off();
+    cleanup(host);
+  });
+});
+
+describe("installEventDelegation — submit events", () => {
+  test("fires on form submit", async () => {
+    let action: string | undefined;
+    const off = installEventDelegation((d) => {
+      d.event.preventDefault();
+      action = d.action;
+    });
+
+    const host = mount(`
+      <form id="f" data-action="team:save">
+        <input name="name" value="x" />
+        <button type="submit">Save</button>
+      </form>
+    `);
+    host.querySelector<HTMLFormElement>("#f")!.requestSubmit();
+    await flush();
+    expect(action).toBe("team:save");
+
+    off();
+    cleanup(host);
+  });
+});
+
+describe("installEventDelegation — keyboard", () => {
+  test("Enter on a non-interactive [data-action] fires the handler", async () => {
+    let action: string | undefined;
+    const off = installEventDelegation((d) => {
+      action = d.action;
+    });
+
+    const host = mount(`
+      <div id="k" tabindex="0" data-action="open:menu" role="button"></div>
+    `);
+    const el = host.querySelector<HTMLDivElement>("#k")!;
+    el.focus();
+    el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    await flush();
+    expect(action).toBe("open:menu");
+
+    off();
+    cleanup(host);
+  });
+
+  test("Enter on a <button> is left to the native click cycle (no double-fire)", async () => {
+    let count = 0;
+    const off = installEventDelegation(() => {
+      count += 1;
+    });
+
+    const host = mount(`<button id="b" data-action="x">B</button>`);
+    const el = host.querySelector<HTMLButtonElement>("#b")!;
+    el.focus();
+    el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    await flush();
+    // keydown for Enter on a BUTTON is not dispatched by the runtime;
+    // the native click cycle will fire click separately (not triggered here).
+    expect(count).toBe(0);
+
+    off();
+    cleanup(host);
+  });
+
+  test("Escape closes the topmost overlay via the registry", async () => {
+    resetOverlayStack();
+    let closedA = 0;
+    let closedB = 0;
+    pushOverlay({ id: "a", onClose: () => (closedA += 1) });
+    pushOverlay({ id: "b", onClose: () => (closedB += 1) });
+
+    const off = installEventDelegation(() => {});
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await flush();
+
+    // installEventDelegation's Escape path uses the DOM-based closeTopOverlay
+    // (dispatches `overlay:close` on the last [data-overlay-id] element).
+    // To also exercise the registry, we close via registry API directly:
+    closeTopOverlay();
+    expect(closedB).toBe(1);
+    expect(closedA).toBe(0);
+
+    off();
+  });
+});
+
+done();

--- a/tests/browser/actions/event-delegation.browser.ts
+++ b/tests/browser/actions/event-delegation.browser.ts
@@ -32,9 +32,7 @@ function mount(html: string): HTMLElement {
 
 describe("installEventDelegation — click events", () => {
   test("fires the handler with parsed data-action-* camelCase", async () => {
-    let seen:
-      | { action: string; data: Record<string, string>; tag: string }
-      | undefined;
+    let seen: { action: string; data: Record<string, string>; tag: string } | undefined;
     const off = installEventDelegation((d) => {
       seen = { action: d.action, data: d.data, tag: d.element.tagName };
     });
@@ -129,9 +127,7 @@ describe("installEventDelegation — keyboard", () => {
     `);
     const el = host.querySelector<HTMLDivElement>("#k")!;
     el.focus();
-    el.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
-    );
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await flush();
     expect(action).toBe("open:menu");
 
@@ -148,9 +144,7 @@ describe("installEventDelegation — keyboard", () => {
     const host = mount(`<button id="b" data-action="x">B</button>`);
     const el = host.querySelector<HTMLButtonElement>("#b")!;
     el.focus();
-    el.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
-    );
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await flush();
     // keydown for Enter on a BUTTON is not dispatched by the runtime;
     // the native click cycle will fire click separately (not triggered here).
@@ -168,9 +162,7 @@ describe("installEventDelegation — keyboard", () => {
     pushOverlay({ id: "b", onClose: () => (closedB += 1) });
 
     const off = installEventDelegation(() => {});
-    document.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
-    );
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     await flush();
 
     // installEventDelegation's Escape path calls closeTopOverlay on the

--- a/tests/browser/ui/primitives.browser.ts
+++ b/tests/browser/ui/primitives.browser.ts
@@ -1,0 +1,309 @@
+/**
+ * UI primitives browser test.
+ *
+ * Covers the critical behaviours of every @fairfox/polly/ui component:
+ * mount/unmount, focus trap, Escape closes top overlay, ActionForm +
+ * createForm round-trip, Toast reads errorState, Layout renders as grid,
+ * TextInput in both modes.
+ */
+
+import { signal } from "@preact/signals";
+import { h, render } from "preact";
+import {
+  type ActionRegistry,
+  clearError,
+  createForm,
+  installEventDelegation,
+  resetOverlayStack,
+  submitError,
+} from "../../../src/actions";
+import {
+  ActionForm,
+  Layout,
+  Modal,
+  OverlayRoot,
+  TextInput,
+  Toast,
+} from "../../../src/polly-ui";
+import {
+  cleanup,
+  describe,
+  done,
+  expect,
+  flush,
+  test,
+} from "../../../tools/test/src/browser/harness";
+
+const app = document.getElementById("app") ?? document.body;
+
+function mountHost(): HTMLElement {
+  const host = document.createElement("div");
+  app.appendChild(host);
+  return host;
+}
+
+describe("OverlayRoot", () => {
+  test("mounts a portal target with data-polly-overlay-root", async () => {
+    const host = mountHost();
+    render(h(OverlayRoot, null), host);
+    await flush();
+    const root = host.querySelector("[data-polly-overlay-root]");
+    expect(root).toExist();
+    cleanup(host);
+  });
+});
+
+describe("Layout", () => {
+  test("renders a grid container with configured tracks", async () => {
+    const host = mountHost();
+    render(
+      h(
+        Layout,
+        { columns: "1fr 1fr", gap: "var(--polly-space-lg)" },
+        h("div", { "data-testid": "a" }, "A"),
+        h("div", { "data-testid": "b" }, "B"),
+      ),
+      host,
+    );
+    await flush();
+    const grid = host.querySelector<HTMLElement>("[data-polly-layout]");
+    expect(grid).toExist();
+    expect(grid!.style.getPropertyValue("--l-cols")).toBe("1fr 1fr");
+    cleanup(host);
+  });
+});
+
+describe("Modal", () => {
+  test("opens on signal change, closes on Escape, restores focus", async () => {
+    const host = mountHost();
+    resetOverlayStack();
+    const open = signal(false);
+    const offDelegation = installEventDelegation(() => {});
+
+    const App = () =>
+      h(
+        "div",
+        null,
+        h("button", {
+          id: "opener",
+          onClick: () => {
+            open.value = true;
+          },
+        }, "open"),
+        h(OverlayRoot, null),
+        h(
+          Modal.Root,
+          { when: open, onClose: () => (open.value = false) },
+          h(Modal.Backdrop, null),
+          h(
+            Modal.Content,
+            null,
+            h(
+              Modal.Header,
+              null,
+              h(Modal.Title, null, "Hello"),
+            ),
+            h(Modal.Body, null, h("input", { id: "first" })),
+            h(
+              Modal.Footer,
+              null,
+              h(Modal.Close, null, "Close"),
+            ),
+          ),
+        ),
+      );
+
+    render(h(App, null), host);
+    await flush();
+
+    const opener = host.querySelector<HTMLButtonElement>("#opener")!;
+    opener.focus();
+    opener.click();
+    await flush();
+
+    const modal = document.querySelector<HTMLElement>(
+      "[data-polly-modal-content]",
+    );
+    expect(modal).toExist();
+    expect(modal!.getAttribute("role")).toBe("dialog");
+    expect(modal!.getAttribute("aria-modal")).toBe("true");
+
+    // Focus should have moved inside the modal.
+    expect(modal!.contains(document.activeElement)).toBe(true);
+
+    // Escape closes.
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await flush();
+    expect(
+      document.querySelector("[data-polly-modal-content]"),
+    ).toBeNull();
+    // Focus restored to the opener.
+    expect(document.activeElement).toBe(opener);
+
+    offDelegation();
+    cleanup(host);
+  });
+
+  test("backdrop click closes the modal", async () => {
+    const host = mountHost();
+    resetOverlayStack();
+    const open = signal(false);
+    const App = () =>
+      h(
+        "div",
+        null,
+        h(OverlayRoot, null),
+        h(
+          Modal.Root,
+          { when: open, onClose: () => (open.value = false) },
+          h(Modal.Backdrop, null),
+          h(Modal.Content, null, h(Modal.Body, null, "body")),
+        ),
+      );
+    render(h(App, null), host);
+    open.value = true;
+    await flush();
+
+    const backdrop = document.querySelector<HTMLElement>(
+      "[data-polly-modal-backdrop]",
+    )!;
+    backdrop.click();
+    await flush();
+    expect(open.value).toBe(false);
+    cleanup(host);
+  });
+});
+
+describe("ActionForm + createForm", () => {
+  test("submit round-trip writes values through to onSubmit", async () => {
+    const host = mountHost();
+    resetOverlayStack();
+
+    type Values = { name: string };
+    type Stores = { received: Values[] };
+    const stores: Stores = { received: [] };
+    const form = createForm<Values, Stores>({
+      name: "test",
+      initialValues: { name: "" },
+      onSubmit: async ({ values, stores: s }) => {
+        s.received.push(values);
+      },
+    });
+    form.bindStores(() => stores);
+
+    const registry: ActionRegistry<Stores> = { ...form.actions };
+    const off = installEventDelegation(async (d) => {
+      const handler = registry[d.action];
+      if (handler) {
+        await handler({
+          stores,
+          event: d.event,
+          element: d.element,
+          data: d.data,
+        });
+      }
+    });
+
+    form.open();
+
+    const App = () =>
+      h(
+        ActionForm<Values, Stores>,
+        { form },
+        h("input", { name: "name", defaultValue: "" }),
+        h("button", { type: "submit", id: "submit-btn" }, "Save"),
+      );
+    render(h(App, null), host);
+    await flush();
+
+    const input = host.querySelector<HTMLInputElement>("input[name=name]")!;
+    input.value = "Alpha";
+    const formEl = host.querySelector<HTMLFormElement>("form")!;
+    formEl.requestSubmit();
+    await flush(100);
+
+    expect(stores.received).toEqual([{ name: "Alpha" }]);
+    expect(form.isOpen.value).toBe(false);
+
+    off();
+    cleanup(host);
+  });
+});
+
+describe("Toast", () => {
+  test("renders entries from errorState and dismisses on click", async () => {
+    const host = mountHost();
+    clearError();
+    const App = () => h("div", null, h(OverlayRoot, null), h(Toast.Viewport, { autoDismissMs: 100000 }));
+    render(h(App, null), host);
+    await flush();
+
+    submitError("x", new Error("boom"));
+    await flush();
+
+    const item = document.querySelector<HTMLElement>(
+      "[data-polly-toast-item]",
+    );
+    expect(item).toExist();
+    expect(item!).toHaveTextContent("boom");
+
+    const close = document.querySelector<HTMLButtonElement>(
+      "[data-polly-toast-close]",
+    )!;
+    close.click();
+    await flush();
+    expect(
+      document.querySelector("[data-polly-toast-item]"),
+    ).toBeNull();
+
+    cleanup(host);
+  });
+});
+
+describe("TextInput", () => {
+  test("uncontrolled mode exposes name + default value for FormData", async () => {
+    const host = mountHost();
+    render(
+      h(
+        "form",
+        { id: "f" },
+        h(TextInput, { name: "handle", value: "seed" }),
+      ),
+      host,
+    );
+    await flush();
+    const input = host.querySelector<HTMLInputElement>("input[name=handle]")!;
+    expect(input.value).toBe("seed");
+    cleanup(host);
+  });
+
+  test("controlled mode writes to the signal on input", async () => {
+    const host = mountHost();
+    const s = signal("");
+    render(h(TextInput, { name: "q", value: s }), host);
+    await flush();
+    const input = host.querySelector<HTMLInputElement>("input[name=q]")!;
+    input.value = "hi";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await flush();
+    expect(s.value).toBe("hi");
+    cleanup(host);
+  });
+
+  test("invalid prop surfaces aria-invalid and data-state", async () => {
+    const host = mountHost();
+    render(
+      h(TextInput, { name: "email", invalid: true, value: "bad" }),
+      host,
+    );
+    await flush();
+    const input = host.querySelector<HTMLInputElement>("input[name=email]")!;
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("data-state")).toBe("invalid");
+    cleanup(host);
+  });
+});
+
+done();

--- a/tests/browser/ui/primitives.browser.tsx
+++ b/tests/browser/ui/primitives.browser.tsx
@@ -8,7 +8,7 @@
  */
 
 import { signal } from "@preact/signals";
-import { h, render } from "preact";
+import { render } from "preact";
 import {
   type ActionRegistry,
   clearError,
@@ -17,14 +17,7 @@ import {
   resetOverlayStack,
   submitError,
 } from "../../../src/actions";
-import {
-  ActionForm,
-  Layout,
-  Modal,
-  OverlayRoot,
-  TextInput,
-  Toast,
-} from "../../../src/polly-ui";
+import { ActionForm, Layout, Modal, OverlayRoot, TextInput, Toast } from "../../../src/polly-ui";
 import {
   cleanup,
   describe,
@@ -45,7 +38,7 @@ function mountHost(): HTMLElement {
 describe("OverlayRoot", () => {
   test("mounts a portal target with data-polly-overlay-root", async () => {
     const host = mountHost();
-    render(h(OverlayRoot, null), host);
+    render(<OverlayRoot />, host);
     await flush();
     const root = host.querySelector("[data-polly-overlay-root]");
     expect(root).toExist();
@@ -57,13 +50,11 @@ describe("Layout", () => {
   test("renders a grid container with configured tracks", async () => {
     const host = mountHost();
     render(
-      h(
-        Layout,
-        { columns: "1fr 1fr", gap: "var(--polly-space-lg)" },
-        h("div", { "data-testid": "a" }, "A"),
-        h("div", { "data-testid": "b" }, "B"),
-      ),
-      host,
+      <Layout columns="1fr 1fr" gap="var(--polly-space-lg)">
+        <div data-testid="a">A</div>
+        <div data-testid="b">B</div>
+      </Layout>,
+      host
     );
     await flush();
     const grid = host.querySelector<HTMLElement>("[data-polly-layout]");
@@ -80,40 +71,38 @@ describe("Modal", () => {
     const open = signal(false);
     const offDelegation = installEventDelegation(() => {});
 
-    const App = () =>
-      h(
-        "div",
-        null,
-        h("button", {
-          id: "opener",
-          onClick: () => {
-            open.value = true;
-          },
-        }, "open"),
-        h(OverlayRoot, null),
-        h(
-          Modal.Root,
-          { when: open, onClose: () => (open.value = false) },
-          h(Modal.Backdrop, null),
-          h(
-            Modal.Content,
-            null,
-            h(
-              Modal.Header,
-              null,
-              h(Modal.Title, null, "Hello"),
-            ),
-            h(Modal.Body, null, h("input", { id: "first" })),
-            h(
-              Modal.Footer,
-              null,
-              h(Modal.Close, null, "Close"),
-            ),
-          ),
-        ),
+    function TestApp() {
+      return (
+        <div>
+          <button
+            id="opener"
+            type="button"
+            onClick={() => {
+              open.value = true;
+            }}
+          >
+            open
+          </button>
+          <OverlayRoot />
+          <Modal.Root when={open} onClose={() => (open.value = false)}>
+            <Modal.Backdrop />
+            <Modal.Content>
+              <Modal.Header>
+                <Modal.Title>Hello</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                <input id="first" />
+              </Modal.Body>
+              <Modal.Footer>
+                <Modal.Close>Close</Modal.Close>
+              </Modal.Footer>
+            </Modal.Content>
+          </Modal.Root>
+        </div>
       );
+    }
 
-    render(h(App, null), host);
+    render(<TestApp />, host);
     await flush();
 
     const opener = host.querySelector<HTMLButtonElement>("#opener")!;
@@ -121,25 +110,15 @@ describe("Modal", () => {
     opener.click();
     await flush();
 
-    const modal = document.querySelector<HTMLElement>(
-      "[data-polly-modal-content]",
-    );
+    const modal = document.querySelector<HTMLElement>("[data-polly-modal-content]");
     expect(modal).toExist();
     expect(modal!.getAttribute("role")).toBe("dialog");
     expect(modal!.getAttribute("aria-modal")).toBe("true");
-
-    // Focus should have moved inside the modal.
     expect(modal!.contains(document.activeElement)).toBe(true);
 
-    // Escape closes.
-    document.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
-    );
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     await flush();
-    expect(
-      document.querySelector("[data-polly-modal-content]"),
-    ).toBeNull();
-    // Focus restored to the opener.
+    expect(document.querySelector("[data-polly-modal-content]")).toBeNull();
     expect(document.activeElement).toBe(opener);
 
     offDelegation();
@@ -150,25 +129,24 @@ describe("Modal", () => {
     const host = mountHost();
     resetOverlayStack();
     const open = signal(false);
-    const App = () =>
-      h(
-        "div",
-        null,
-        h(OverlayRoot, null),
-        h(
-          Modal.Root,
-          { when: open, onClose: () => (open.value = false) },
-          h(Modal.Backdrop, null),
-          h(Modal.Content, null, h(Modal.Body, null, "body")),
-        ),
+    function TestApp() {
+      return (
+        <div>
+          <OverlayRoot />
+          <Modal.Root when={open} onClose={() => (open.value = false)}>
+            <Modal.Backdrop />
+            <Modal.Content>
+              <Modal.Body>body</Modal.Body>
+            </Modal.Content>
+          </Modal.Root>
+        </div>
       );
-    render(h(App, null), host);
+    }
+    render(<TestApp />, host);
     open.value = true;
     await flush();
 
-    const backdrop = document.querySelector<HTMLElement>(
-      "[data-polly-modal-backdrop]",
-    )!;
+    const backdrop = document.querySelector<HTMLElement>("[data-polly-modal-backdrop]")!;
     backdrop.click();
     await flush();
     expect(open.value).toBe(false);
@@ -208,14 +186,17 @@ describe("ActionForm + createForm", () => {
 
     form.open();
 
-    const App = () =>
-      h(
-        ActionForm<Values, Stores>,
-        { form },
-        h("input", { name: "name", defaultValue: "" }),
-        h("button", { type: "submit", id: "submit-btn" }, "Save"),
+    function TestApp() {
+      return (
+        <ActionForm<Values, Stores> form={form}>
+          <input name="name" defaultValue="" />
+          <button type="submit" id="submit-btn">
+            Save
+          </button>
+        </ActionForm>
       );
-    render(h(App, null), host);
+    }
+    render(<TestApp />, host);
     await flush();
 
     const input = host.querySelector<HTMLInputElement>("input[name=name]")!;
@@ -236,27 +217,28 @@ describe("Toast", () => {
   test("renders entries from errorState and dismisses on click", async () => {
     const host = mountHost();
     clearError();
-    const App = () => h("div", null, h(OverlayRoot, null), h(Toast.Viewport, { autoDismissMs: 100000 }));
-    render(h(App, null), host);
+    function TestApp() {
+      return (
+        <div>
+          <OverlayRoot />
+          <Toast.Viewport autoDismissMs={100000} />
+        </div>
+      );
+    }
+    render(<TestApp />, host);
     await flush();
 
     submitError("x", new Error("boom"));
     await flush();
 
-    const item = document.querySelector<HTMLElement>(
-      "[data-polly-toast-item]",
-    );
+    const item = document.querySelector<HTMLElement>("[data-polly-toast-item]");
     expect(item).toExist();
     expect(item!).toHaveTextContent("boom");
 
-    const close = document.querySelector<HTMLButtonElement>(
-      "[data-polly-toast-close]",
-    )!;
+    const close = document.querySelector<HTMLButtonElement>("[data-polly-toast-close]")!;
     close.click();
     await flush();
-    expect(
-      document.querySelector("[data-polly-toast-item]"),
-    ).toBeNull();
+    expect(document.querySelector("[data-polly-toast-item]")).toBeNull();
 
     cleanup(host);
   });
@@ -266,12 +248,10 @@ describe("TextInput", () => {
   test("uncontrolled mode exposes name + default value for FormData", async () => {
     const host = mountHost();
     render(
-      h(
-        "form",
-        { id: "f" },
-        h(TextInput, { name: "handle", value: "seed" }),
-      ),
-      host,
+      <form id="f">
+        <TextInput name="handle" value="seed" />
+      </form>,
+      host
     );
     await flush();
     const input = host.querySelector<HTMLInputElement>("input[name=handle]")!;
@@ -282,7 +262,7 @@ describe("TextInput", () => {
   test("controlled mode writes to the signal on input", async () => {
     const host = mountHost();
     const s = signal("");
-    render(h(TextInput, { name: "q", value: s }), host);
+    render(<TextInput name="q" value={s} />, host);
     await flush();
     const input = host.querySelector<HTMLInputElement>("input[name=q]")!;
     input.value = "hi";
@@ -294,10 +274,7 @@ describe("TextInput", () => {
 
   test("invalid prop surfaces aria-invalid and data-state", async () => {
     const host = mountHost();
-    render(
-      h(TextInput, { name: "email", invalid: true, value: "bad" }),
-      host,
-    );
+    render(<TextInput name="email" invalid value="bad" />, host);
     await flush();
     const input = host.querySelector<HTMLInputElement>("input[name=email]")!;
     expect(input.getAttribute("aria-invalid")).toBe("true");

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -16,7 +16,8 @@
       "@fairfox/polly/adapters": ["../src/shared/adapters/index.ts"],
       "@fairfox/polly/errors": ["../src/shared/lib/errors.ts"],
       "@fairfox/polly/types": ["../src/shared/types/messages.ts"],
-      "@fairfox/polly/test": ["../tools/test/src/index.ts"]
+      "@fairfox/polly/test": ["../tools/test/src/index.ts"],
+      "@fairfox/polly/actions": ["../src/actions/index.ts"]
     }
   },
   "include": ["./**/*"],

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -21,6 +21,6 @@
       "@fairfox/polly/actions": ["../src/actions/index.ts"]
     }
   },
-  "include": ["./**/*"],
+  "include": ["./**/*", "../src/polly-ui/css-modules.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -17,6 +17,7 @@
       "@fairfox/polly/errors": ["../src/shared/lib/errors.ts"],
       "@fairfox/polly/types": ["../src/shared/types/messages.ts"],
       "@fairfox/polly/test": ["../tools/test/src/index.ts"],
+      "@fairfox/polly/quality": ["../tools/quality/src/index.ts"],
       "@fairfox/polly/actions": ["../src/actions/index.ts"]
     }
   },

--- a/tests/unit/actions/error.test.ts
+++ b/tests/unit/actions/error.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, expect, test } from "bun:test";
+import {
+  clearError,
+  errorState,
+  setError,
+  submitError,
+} from "@fairfox/polly/actions";
+
+beforeEach(() => {
+  clearError();
+});
+
+test("setError appends to errorState with default severity error", () => {
+  const id = setError("Boom");
+  expect(errorState.value.length).toBe(1);
+  const entry = errorState.value[0];
+  expect(entry?.id).toBe(id);
+  expect(entry?.message).toBe("Boom");
+  expect(entry?.severity).toBe("error");
+  expect(entry?.createdAt).toBeGreaterThan(0);
+});
+
+test("setError honours severity and action options", () => {
+  setError("Slowed down", { severity: "warning", action: "sync:pull" });
+  const entry = errorState.value[0];
+  expect(entry?.severity).toBe("warning");
+  expect(entry?.action).toBe("sync:pull");
+});
+
+test("clearError by id removes one entry", () => {
+  const idA = setError("A");
+  setError("B");
+  clearError(idA);
+  expect(errorState.value.map((e) => e.message)).toEqual(["B"]);
+});
+
+test("clearError with no id clears all", () => {
+  setError("A");
+  setError("B");
+  clearError();
+  expect(errorState.value).toEqual([]);
+});
+
+test("submitError records the action and derives message from an Error", () => {
+  submitError("team:submit", new Error("conflict"));
+  const entry = errorState.value[0];
+  expect(entry?.message).toBe("conflict");
+  expect(entry?.action).toBe("team:submit");
+  expect(entry?.severity).toBe("error");
+});
+
+test("submitError coerces non-Error values via String()", () => {
+  submitError("team:submit", "string failure");
+  expect(errorState.value[0]?.message).toBe("string failure");
+});

--- a/tests/unit/actions/error.test.ts
+++ b/tests/unit/actions/error.test.ts
@@ -1,10 +1,5 @@
 import { beforeEach, expect, test } from "bun:test";
-import {
-  clearError,
-  errorState,
-  setError,
-  submitError,
-} from "@fairfox/polly/actions";
+import { clearError, errorState, setError, submitError } from "@fairfox/polly/actions";
 
 beforeEach(() => {
   clearError();

--- a/tests/unit/actions/form.test.ts
+++ b/tests/unit/actions/form.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, expect, test } from "bun:test";
+import {
+  clearError,
+  createForm,
+  createFormSet,
+  errorState,
+  runAction,
+} from "@fairfox/polly/actions";
+import { signal } from "@preact/signals";
+
+type TeamValues = { name: string; description: string };
+type TestStores = {
+  teams: { value: Array<{ id: string; name: string }> };
+  modalEntityId: { value: string | null };
+  createCalls: TeamValues[];
+};
+
+function makeStores(): TestStores {
+  return {
+    teams: signal<Array<{ id: string; name: string }>>([]),
+    modalEntityId: signal<string | null>(null),
+    createCalls: [],
+  } as unknown as TestStores;
+}
+
+beforeEach(() => {
+  clearError();
+});
+
+test("form exposes initial field signals and values signal", () => {
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    onSubmit: async ({ values, stores }) => {
+      stores.createCalls.push(values);
+    },
+  });
+  expect(form.fields.name.value).toBe("");
+  expect(form.fields.description.value).toBe("");
+  expect(form.values.value).toEqual({ name: "", description: "" });
+  expect(form.isOpen.value).toBe(false);
+});
+
+test("open records openParams, sets isOpen, applies overrides", () => {
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    onSubmit: async () => {},
+  });
+  form.bindStores(() => makeStores());
+  form.open({ name: "Seed" }, { entityId: "42" });
+  expect(form.isOpen.value).toBe(true);
+  expect(form.openParams.value).toEqual({ entityId: "42" });
+  expect(form.fields.name.value).toBe("Seed");
+  expect(form.fields.description.value).toBe("");
+});
+
+test("close resets fields and clears openParams", () => {
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    onSubmit: async () => {},
+  });
+  form.bindStores(() => makeStores());
+  form.open({ name: "Seed" }, { entityId: "42" });
+  form.close();
+  expect(form.isOpen.value).toBe(false);
+  expect(form.fields.name.value).toBe("");
+  expect(form.openParams.value).toEqual({});
+});
+
+test("onOpen overrides initial values using stores", () => {
+  const stores = makeStores();
+  stores.teams.value = [{ id: "42", name: "Seed" }];
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    onOpen: ({ data, stores: s }) => {
+      const entity = s.teams.value.find((t) => t.id === data.entityId);
+      return entity ? { name: entity.name } : {};
+    },
+    onSubmit: async () => {},
+  });
+  form.bindStores(() => stores);
+  form.open(undefined, { entityId: "42" });
+  expect(form.fields.name.value).toBe("Seed");
+});
+
+test("validate blocks submit and populates errors", async () => {
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    validate: (v) => (v.name === "" ? { name: "required" } : null),
+    onSubmit: async ({ stores }) => {
+      stores.createCalls.push({ name: "never", description: "" });
+    },
+  });
+  const stores = makeStores();
+  form.bindStores(() => stores);
+  form.open();
+  await form.submit();
+  expect(form.errors.value).toEqual({ name: "required" });
+  expect(stores.createCalls.length).toBe(0);
+});
+
+test("submit runs onSubmit with current values and closes on success", async () => {
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    onSubmit: async ({ values, stores }) => {
+      stores.createCalls.push(values);
+    },
+  });
+  const stores = makeStores();
+  form.bindStores(() => stores);
+  form.open();
+  form.fields.name.value = "New team";
+  form.fields.description.value = "x";
+  await form.submit();
+  expect(stores.createCalls).toEqual([{ name: "New team", description: "x" }]);
+  expect(form.isOpen.value).toBe(false);
+});
+
+test("submit routes thrown errors through submitError", async () => {
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    onSubmit: async () => {
+      throw new Error("conflict");
+    },
+  });
+  form.bindStores(() => makeStores());
+  form.open();
+  form.fields.name.value = "x";
+  await form.submit();
+  expect(errorState.value.some((e) => e.message === "conflict")).toBe(true);
+  expect(form.isSubmitting.value).toBe(false);
+});
+
+test("auto-registered actions open, close, and submit via runAction", async () => {
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    onSubmit: async ({ values, stores }) => {
+      stores.createCalls.push(values);
+    },
+  });
+  const stores = makeStores();
+  form.bindStores(() => stores);
+
+  await runAction(form.actions, "team:open", {
+    stores,
+    data: { entityId: "42" },
+  });
+  expect(form.isOpen.value).toBe(true);
+  expect(form.openParams.value).toEqual({ entityId: "42" });
+
+  form.fields.name.value = "T";
+  form.fields.description.value = "D";
+  await runAction(form.actions, "team:submit", { stores });
+  expect(stores.createCalls).toEqual([{ name: "T", description: "D" }]);
+  expect(form.isOpen.value).toBe(false);
+});
+
+test("guard closes form when predicate turns false while open", () => {
+  const stores = makeStores();
+  stores.teams.value = [{ id: "42", name: "x" }];
+  stores.modalEntityId.value = "42";
+  const form = createForm<TeamValues, TestStores>({
+    name: "team",
+    initialValues: { name: "", description: "" },
+    guard: ({ stores: s }) =>
+      s.teams.value.some((t) => t.id === s.modalEntityId.value),
+    onSubmit: async () => {},
+  });
+  form.bindStores(() => stores);
+  form.open(undefined, { entityId: "42" });
+  expect(form.isOpen.value).toBe(true);
+  stores.teams.value = [];
+  expect(form.isOpen.value).toBe(false);
+});
+
+test("createFormSet merges actions and exposes openForm signal", () => {
+  const formA = createForm<TeamValues, TestStores>({
+    name: "a",
+    initialValues: { name: "", description: "" },
+    onSubmit: async () => {},
+  });
+  const formB = createForm<TeamValues, TestStores>({
+    name: "b",
+    initialValues: { name: "", description: "" },
+    onSubmit: async () => {},
+  });
+  const set = createFormSet<TestStores>([formA, formB]);
+  set.bindStores(() => makeStores());
+
+  expect(Object.keys(set.actions).sort()).toEqual([
+    "a:close",
+    "a:open",
+    "a:submit",
+    "b:close",
+    "b:open",
+    "b:submit",
+  ]);
+  expect(set.openForm.value).toBeNull();
+  formA.open();
+  expect(set.openForm.value).toBe("a");
+  formA.close();
+  formB.open();
+  expect(set.openForm.value).toBe("b");
+  set.closeAll();
+  expect(set.openForm.value).toBeNull();
+});

--- a/tests/unit/actions/form.test.ts
+++ b/tests/unit/actions/form.test.ts
@@ -169,8 +169,7 @@ test("guard closes form when predicate turns false while open", () => {
   const form = createForm<TeamValues, TestStores>({
     name: "team",
     initialValues: { name: "", description: "" },
-    guard: ({ stores: s }) =>
-      s.teams.value.some((t) => t.id === s.modalEntityId.value),
+    guard: ({ stores: s }) => s.teams.value.some((t) => t.id === s.modalEntityId.value),
     onSubmit: async () => {},
   });
   form.bindStores(() => stores);

--- a/tests/unit/actions/overlay.test.ts
+++ b/tests/unit/actions/overlay.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, expect, test } from "bun:test";
+import {
+  closeTopOverlay,
+  hasOpenOverlay,
+  overlayStack,
+  popOverlay,
+  pushOverlay,
+  resetOverlayStack,
+  topOverlay,
+} from "@fairfox/polly/actions";
+
+beforeEach(() => {
+  resetOverlayStack();
+});
+
+test("push then top returns the pushed entry", () => {
+  pushOverlay({ id: "modal-a" });
+  expect(topOverlay()?.id).toBe("modal-a");
+  expect(hasOpenOverlay()).toBe(true);
+});
+
+test("stack order reflects push order; top is last pushed", () => {
+  pushOverlay({ id: "a" });
+  pushOverlay({ id: "b" });
+  pushOverlay({ id: "c" });
+  expect(overlayStack().map((e) => e.id)).toEqual(["a", "b", "c"]);
+  expect(topOverlay()?.id).toBe("c");
+});
+
+test("popOverlay without id pops top and returns it", () => {
+  pushOverlay({ id: "a" });
+  pushOverlay({ id: "b" });
+  const popped = popOverlay();
+  expect(popped?.id).toBe("b");
+  expect(topOverlay()?.id).toBe("a");
+});
+
+test("popOverlay with id removes the named entry wherever it is", () => {
+  pushOverlay({ id: "a" });
+  pushOverlay({ id: "b" });
+  pushOverlay({ id: "c" });
+  const popped = popOverlay("b");
+  expect(popped?.id).toBe("b");
+  expect(overlayStack().map((e) => e.id)).toEqual(["a", "c"]);
+});
+
+test("popOverlay returns undefined when id not found", () => {
+  pushOverlay({ id: "a" });
+  expect(popOverlay("missing")).toBeUndefined();
+  expect(overlayStack().map((e) => e.id)).toEqual(["a"]);
+});
+
+test("closeTopOverlay fires onClose and pops the top", () => {
+  let closedId: string | undefined;
+  pushOverlay({ id: "a" });
+  pushOverlay({ id: "b", onClose: () => (closedId = "b") });
+  closeTopOverlay();
+  expect(closedId).toBe("b");
+  expect(topOverlay()?.id).toBe("a");
+});
+
+test("closeTopOverlay on empty stack is a no-op", () => {
+  expect(closeTopOverlay()).toBeUndefined();
+  expect(hasOpenOverlay()).toBe(false);
+});

--- a/tests/unit/actions/parse-action-data.test.ts
+++ b/tests/unit/actions/parse-action-data.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { parseActionData } from "@fairfox/polly/actions";
+import { createMockElement } from "@fairfox/polly/actions";
+
+test("camelCases data-action-* attribute names", () => {
+  const el = createMockElement({
+    "data-action-text-set-id": "42",
+    "data-action-variant-id": "3",
+  });
+  const result = parseActionData(el);
+  expect(result).toEqual({ textSetId: "42", variantId: "3" });
+});
+
+test("ignores non data-action-* attributes", () => {
+  const el = createMockElement({
+    "data-action-value": "v",
+    "data-other": "o",
+    "aria-label": "x",
+  });
+  const result = parseActionData(el);
+  expect(result).toEqual({ value: "v" });
+});
+
+test("returns an empty object when no matching attributes", () => {
+  const el = createMockElement({ class: "thing", role: "button" });
+  const result = parseActionData(el);
+  expect(result).toEqual({});
+});
+
+test("preserves empty string values", () => {
+  const el = createMockElement({ "data-action-value": "" });
+  const result = parseActionData(el);
+  expect(result).toEqual({ value: "" });
+});

--- a/tests/unit/actions/parse-action-data.test.ts
+++ b/tests/unit/actions/parse-action-data.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "bun:test";
-import { parseActionData } from "@fairfox/polly/actions";
-import { createMockElement } from "@fairfox/polly/actions";
+import { createMockElement, parseActionData } from "@fairfox/polly/actions";
 
 test("camelCases data-action-* attribute names", () => {
   const el = createMockElement({

--- a/tests/unit/actions/testing.test.ts
+++ b/tests/unit/actions/testing.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import {
+  createMockElement,
+  createMockStores,
+  createMockSubmitEvent,
+  parseActionData,
+  runAction,
+} from "@fairfox/polly/actions";
+import type { ActionRegistry } from "@fairfox/polly/actions";
+
+test("createMockElement exposes attributes compatible with parseActionData", () => {
+  const el = createMockElement({
+    "data-action-foo-bar": "x",
+    "data-action-value": "y",
+  });
+  expect(parseActionData(el)).toEqual({ fooBar: "x", value: "y" });
+});
+
+test("createMockSubmitEvent has preventDefault behaviour", () => {
+  const event = createMockSubmitEvent({});
+  expect(event.type).toBe("submit");
+  expect(event.defaultPrevented).toBe(false);
+  event.preventDefault();
+  expect(event.defaultPrevented).toBe(true);
+});
+
+test("createMockStores returns the partial cast as the stores type", () => {
+  const stores = createMockStores<{ count: number }>({ count: 1 });
+  expect(stores.count).toBe(1);
+});
+
+test("runAction invokes the registered handler with context defaults", async () => {
+  let seen: Record<string, string> | undefined;
+  const registry: ActionRegistry<{ x: number }> = {
+    "ping": ({ data }) => {
+      seen = data;
+    },
+  };
+  await runAction(registry, "ping", { stores: { x: 1 }, data: { a: "1" } });
+  expect(seen).toEqual({ a: "1" });
+});
+
+test("runAction throws when the handler is absent", async () => {
+  const registry: ActionRegistry<{}> = {};
+  await expect(runAction(registry, "missing", { stores: {} })).rejects.toThrow(
+    /No handler registered/,
+  );
+});

--- a/tests/unit/actions/testing.test.ts
+++ b/tests/unit/actions/testing.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import type { ActionRegistry } from "@fairfox/polly/actions";
 import {
   createMockElement,
   createMockStores,
@@ -6,7 +7,6 @@ import {
   parseActionData,
   runAction,
 } from "@fairfox/polly/actions";
-import type { ActionRegistry } from "@fairfox/polly/actions";
 
 test("createMockElement exposes attributes compatible with parseActionData", () => {
   const el = createMockElement({
@@ -32,7 +32,7 @@ test("createMockStores returns the partial cast as the stores type", () => {
 test("runAction invokes the registered handler with context defaults", async () => {
   let seen: Record<string, string> | undefined;
   const registry: ActionRegistry<{ x: number }> = {
-    "ping": ({ data }) => {
+    ping: ({ data }) => {
       seen = data;
     },
   };
@@ -43,6 +43,6 @@ test("runAction invokes the registered handler with context defaults", async () 
 test("runAction throws when the handler is absent", async () => {
   const registry: ActionRegistry<{}> = {};
   await expect(runAction(registry, "missing", { stores: {} })).rejects.toThrow(
-    /No handler registered/,
+    /No handler registered/
   );
 });

--- a/tests/unit/quality/css/check-layout.test.ts
+++ b/tests/unit/quality/css/check-layout.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, expect, test } from "bun:test";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, expect, test } from "bun:test";
 import { checkCssLayout } from "@fairfox/polly/quality";
 
 let root: string;
@@ -31,19 +31,13 @@ test("flags display: grid in a non-Layout CSS module", async () => {
 });
 
 test("exempts Layout.module.css", async () => {
-  await writeFileAt(
-    "ui/Layout.module.css",
-    `.layout { display: grid; }`,
-  );
+  await writeFileAt("ui/Layout.module.css", `.layout { display: grid; }`);
   const r = await checkCssLayout({ rootDir: root });
   expect(r.violations).toEqual([]);
 });
 
 test("exempts a line suppressed by /* layout-ignore */ on the same line", async () => {
-  await writeFileAt(
-    "components/Card.module.css",
-    `.x { display: flex; /* layout-ignore */ }`,
-  );
+  await writeFileAt("components/Card.module.css", `.x { display: flex; /* layout-ignore */ }`);
   const r = await checkCssLayout({ rootDir: root });
   expect(r.violations).toEqual([]);
 });
@@ -52,7 +46,7 @@ test("exempts a line suppressed by /* layout-ignore */ on the preceding line", a
   await writeFileAt(
     "components/Card.module.css",
     `/* layout-ignore */
-.x { display: flex; }`,
+.x { display: flex; }`
   );
   const r = await checkCssLayout({ rootDir: root });
   expect(r.violations).toEqual([]);
@@ -61,7 +55,7 @@ test("exempts a line suppressed by /* layout-ignore */ on the preceding line", a
 test("flags inline display: 'flex' in TSX", async () => {
   await writeFileAt(
     "components/Card.tsx",
-    `export const X = () => <div style={{ display: "flex" }} />;`,
+    `export const X = () => <div style={{ display: "flex" }} />;`
   );
   const r = await checkCssLayout({ rootDir: root });
   expect(r.violations.length).toBe(1);
@@ -69,10 +63,7 @@ test("flags inline display: 'flex' in TSX", async () => {
 });
 
 test("custom layoutExemptPaths is honoured", async () => {
-  await writeFileAt(
-    "components/MyStack.module.css",
-    `.stack { display: flex; }`,
-  );
+  await writeFileAt("components/MyStack.module.css", `.stack { display: flex; }`);
   const r = await checkCssLayout({
     rootDir: root,
     layoutExemptPaths: ["MyStack.module.css"],

--- a/tests/unit/quality/css/check-layout.test.ts
+++ b/tests/unit/quality/css/check-layout.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, expect, test } from "bun:test";
+import { checkCssLayout } from "@fairfox/polly/quality";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "polly-css-l-"));
+});
+
+async function writeFileAt(path: string, content: string): Promise<void> {
+  const full = join(root, path);
+  const dir = full.substring(0, full.lastIndexOf("/"));
+  await mkdir(dir, { recursive: true });
+  await writeFile(full, content);
+}
+
+test("flags display: flex in a non-Layout CSS module", async () => {
+  await writeFileAt("components/Card.module.css", `.x { display: flex; }`);
+  const r = await checkCssLayout({ rootDir: root });
+  expect(r.violations.length).toBe(1);
+  expect(r.violations[0]?.rule).toContain("flex");
+});
+
+test("flags display: grid in a non-Layout CSS module", async () => {
+  await writeFileAt("components/Card.module.css", `.x { display: grid; }`);
+  const r = await checkCssLayout({ rootDir: root });
+  expect(r.violations[0]?.rule).toContain("grid");
+});
+
+test("exempts Layout.module.css", async () => {
+  await writeFileAt(
+    "ui/Layout.module.css",
+    `.layout { display: grid; }`,
+  );
+  const r = await checkCssLayout({ rootDir: root });
+  expect(r.violations).toEqual([]);
+});
+
+test("exempts a line suppressed by /* layout-ignore */ on the same line", async () => {
+  await writeFileAt(
+    "components/Card.module.css",
+    `.x { display: flex; /* layout-ignore */ }`,
+  );
+  const r = await checkCssLayout({ rootDir: root });
+  expect(r.violations).toEqual([]);
+});
+
+test("exempts a line suppressed by /* layout-ignore */ on the preceding line", async () => {
+  await writeFileAt(
+    "components/Card.module.css",
+    `/* layout-ignore */
+.x { display: flex; }`,
+  );
+  const r = await checkCssLayout({ rootDir: root });
+  expect(r.violations).toEqual([]);
+});
+
+test("flags inline display: 'flex' in TSX", async () => {
+  await writeFileAt(
+    "components/Card.tsx",
+    `export const X = () => <div style={{ display: "flex" }} />;`,
+  );
+  const r = await checkCssLayout({ rootDir: root });
+  expect(r.violations.length).toBe(1);
+  expect(r.violations[0]?.rule).toContain("inline");
+});
+
+test("custom layoutExemptPaths is honoured", async () => {
+  await writeFileAt(
+    "components/MyStack.module.css",
+    `.stack { display: flex; }`,
+  );
+  const r = await checkCssLayout({
+    rootDir: root,
+    layoutExemptPaths: ["MyStack.module.css"],
+  });
+  expect(r.violations).toEqual([]);
+});

--- a/tests/unit/quality/css/check-quality.test.ts
+++ b/tests/unit/quality/css/check-quality.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, expect, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, expect, test } from "bun:test";
 import { checkCssQuality } from "@fairfox/polly/quality";
 
 let root: string;
@@ -23,7 +23,7 @@ test("passes when every value uses a semantic token", async () => {
   z-index: var(--polly-z-overlay);
   border-radius: var(--polly-radius-md);
   font-weight: var(--polly-weight-bold);
-}`,
+}`
   );
   const result = await checkCssQuality({ rootDir: root });
   expect(result.violations).toEqual([]);
@@ -32,9 +32,7 @@ test("passes when every value uses a semantic token", async () => {
 test("flags hardcoded hex colours", async () => {
   await writeCss("bad.module.css", `.x { color: #ff0000; }`);
   const result = await checkCssQuality({ rootDir: root });
-  expect(result.violations.map((v) => v.rule)).toContain(
-    "no-hardcoded-color",
-  );
+  expect(result.violations.map((v) => v.rule)).toContain("no-hardcoded-color");
 });
 
 test("flags !important", async () => {
@@ -46,9 +44,7 @@ test("flags !important", async () => {
 test("flags numeric font-weight", async () => {
   await writeCss("bad.module.css", `.x { font-weight: 700; }`);
   const result = await checkCssQuality({ rootDir: root });
-  expect(
-    result.violations.some((v) => v.rule === "no-hardcoded-font-weight"),
-  ).toBe(true);
+  expect(result.violations.some((v) => v.rule === "no-hardcoded-font-weight")).toBe(true);
 });
 
 test("flags rem units outside calc()", async () => {
@@ -60,43 +56,31 @@ test("flags rem units outside calc()", async () => {
 test("flags hardcoded border-radius", async () => {
   await writeCss("bad.module.css", `.x { border-radius: 8px; }`);
   const result = await checkCssQuality({ rootDir: root });
-  expect(
-    result.violations.some((v) => v.rule === "no-hardcoded-border-radius"),
-  ).toBe(true);
+  expect(result.violations.some((v) => v.rule === "no-hardcoded-border-radius")).toBe(true);
 });
 
 test("skips files with polly-ignore-all on line 1", async () => {
   await writeCss(
     "ignored.module.css",
     `/* polly-ignore-all */
-.x { color: red; font-weight: 900; }`,
+.x { color: red; font-weight: 900; }`
   );
   const result = await checkCssQuality({ rootDir: root });
   expect(result.violations).toEqual([]);
 });
 
 test("honours disableRules option", async () => {
-  await writeCss(
-    "partial.module.css",
-    `.x { color: #333; font-weight: 700; }`,
-  );
+  await writeCss("partial.module.css", `.x { color: #333; font-weight: 700; }`);
   const result = await checkCssQuality({
     rootDir: root,
     disableRules: ["no-hardcoded-color"],
   });
-  expect(result.violations.some((v) => v.rule === "no-hardcoded-color")).toBe(
-    false,
-  );
-  expect(
-    result.violations.some((v) => v.rule === "no-hardcoded-font-weight"),
-  ).toBe(true);
+  expect(result.violations.some((v) => v.rule === "no-hardcoded-color")).toBe(false);
+  expect(result.violations.some((v) => v.rule === "no-hardcoded-font-weight")).toBe(true);
 });
 
 test("theme.css is skipped by default (defines raw values)", async () => {
-  await writeCss(
-    "theme.css",
-    `:root { --polly-text: #111; --polly-surface: #fff; }`,
-  );
+  await writeCss("theme.css", `:root { --polly-text: #111; --polly-surface: #fff; }`);
   const result = await checkCssQuality({ rootDir: root });
   expect(result.violations).toEqual([]);
 });

--- a/tests/unit/quality/css/check-quality.test.ts
+++ b/tests/unit/quality/css/check-quality.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, expect, test } from "bun:test";
+import { checkCssQuality } from "@fairfox/polly/quality";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "polly-css-q-"));
+});
+
+async function writeCss(name: string, content: string): Promise<void> {
+  await writeFile(join(root, name), content);
+}
+
+test("passes when every value uses a semantic token", async () => {
+  await writeCss(
+    "ok.module.css",
+    `.box {
+  color: var(--polly-text);
+  background: var(--polly-surface);
+  z-index: var(--polly-z-overlay);
+  border-radius: var(--polly-radius-md);
+  font-weight: var(--polly-weight-bold);
+}`,
+  );
+  const result = await checkCssQuality({ rootDir: root });
+  expect(result.violations).toEqual([]);
+});
+
+test("flags hardcoded hex colours", async () => {
+  await writeCss("bad.module.css", `.x { color: #ff0000; }`);
+  const result = await checkCssQuality({ rootDir: root });
+  expect(result.violations.map((v) => v.rule)).toContain(
+    "no-hardcoded-color",
+  );
+});
+
+test("flags !important", async () => {
+  await writeCss("bad.module.css", `.x { color: red !important; }`);
+  const result = await checkCssQuality({ rootDir: root });
+  expect(result.violations.some((v) => v.rule === "no-important")).toBe(true);
+});
+
+test("flags numeric font-weight", async () => {
+  await writeCss("bad.module.css", `.x { font-weight: 700; }`);
+  const result = await checkCssQuality({ rootDir: root });
+  expect(
+    result.violations.some((v) => v.rule === "no-hardcoded-font-weight"),
+  ).toBe(true);
+});
+
+test("flags rem units outside calc()", async () => {
+  await writeCss("bad.module.css", `.x { padding: 1rem; }`);
+  const result = await checkCssQuality({ rootDir: root });
+  expect(result.violations.some((v) => v.rule === "no-rem-units")).toBe(true);
+});
+
+test("flags hardcoded border-radius", async () => {
+  await writeCss("bad.module.css", `.x { border-radius: 8px; }`);
+  const result = await checkCssQuality({ rootDir: root });
+  expect(
+    result.violations.some((v) => v.rule === "no-hardcoded-border-radius"),
+  ).toBe(true);
+});
+
+test("skips files with polly-ignore-all on line 1", async () => {
+  await writeCss(
+    "ignored.module.css",
+    `/* polly-ignore-all */
+.x { color: red; font-weight: 900; }`,
+  );
+  const result = await checkCssQuality({ rootDir: root });
+  expect(result.violations).toEqual([]);
+});
+
+test("honours disableRules option", async () => {
+  await writeCss(
+    "partial.module.css",
+    `.x { color: #333; font-weight: 700; }`,
+  );
+  const result = await checkCssQuality({
+    rootDir: root,
+    disableRules: ["no-hardcoded-color"],
+  });
+  expect(result.violations.some((v) => v.rule === "no-hardcoded-color")).toBe(
+    false,
+  );
+  expect(
+    result.violations.some((v) => v.rule === "no-hardcoded-font-weight"),
+  ).toBe(true);
+});
+
+test("theme.css is skipped by default (defines raw values)", async () => {
+  await writeCss(
+    "theme.css",
+    `:root { --polly-text: #111; --polly-surface: #fff; }`,
+  );
+  const result = await checkCssQuality({ rootDir: root });
+  expect(result.violations).toEqual([]);
+});

--- a/tests/unit/quality/css/check-unused.test.ts
+++ b/tests/unit/quality/css/check-unused.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, expect, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, expect, test } from "bun:test";
 import { checkCssUnused } from "@fairfox/polly/quality";
 
 let root: string;
@@ -14,11 +14,11 @@ test("flags a class with no TS reference", async () => {
   await writeFile(
     join(root, "Card.module.css"),
     `.container { color: red; }
-.unused { color: blue; }`,
+.unused { color: blue; }`
   );
   await writeFile(
     join(root, "Card.tsx"),
-    `import styles from "./Card.module.css"; export const X = () => <div className={styles.container} />;`,
+    `import styles from "./Card.module.css"; export const X = () => <div className={styles.container} />;`
   );
   const r = await checkCssUnused({ rootDir: root });
   expect(r.violations.length).toBe(1);
@@ -26,10 +26,7 @@ test("flags a class with no TS reference", async () => {
 });
 
 test("alwaysUsedClasses silences the report for a named class", async () => {
-  await writeFile(
-    join(root, "Card.module.css"),
-    `.dynamic { color: red; }`,
-  );
+  await writeFile(join(root, "Card.module.css"), `.dynamic { color: red; }`);
   await writeFile(join(root, "Card.tsx"), `export const X = () => null;`);
   const r = await checkCssUnused({
     rootDir: root,
@@ -42,11 +39,11 @@ test("passes when every class is referenced from TSX", async () => {
   await writeFile(
     join(root, "Card.module.css"),
     `.a { color: red; }
-.b { color: blue; }`,
+.b { color: blue; }`
   );
   await writeFile(
     join(root, "Card.tsx"),
-    `import s from "./Card.module.css"; export const X = () => <div className={s.a + " " + s.b} />;`,
+    `import s from "./Card.module.css"; export const X = () => <div className={s.a + " " + s.b} />;`
   );
   const r = await checkCssUnused({ rootDir: root });
   expect(r.violations).toEqual([]);
@@ -58,7 +55,7 @@ test("flags a locally-defined variable with no reference", async () => {
     `.c {
   --card-local: 10px;
   padding: 2px;
-}`,
+}`
   );
   const r = await checkCssUnused({ rootDir: root });
   expect(r.violations.some((v) => v.content === "--card-local")).toBe(true);

--- a/tests/unit/quality/css/check-unused.test.ts
+++ b/tests/unit/quality/css/check-unused.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, expect, test } from "bun:test";
+import { checkCssUnused } from "@fairfox/polly/quality";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "polly-css-u-"));
+});
+
+test("flags a class with no TS reference", async () => {
+  await writeFile(
+    join(root, "Card.module.css"),
+    `.container { color: red; }
+.unused { color: blue; }`,
+  );
+  await writeFile(
+    join(root, "Card.tsx"),
+    `import styles from "./Card.module.css"; export const X = () => <div className={styles.container} />;`,
+  );
+  const r = await checkCssUnused({ rootDir: root });
+  expect(r.violations.length).toBe(1);
+  expect(r.violations[0]?.content).toBe(".unused");
+});
+
+test("alwaysUsedClasses silences the report for a named class", async () => {
+  await writeFile(
+    join(root, "Card.module.css"),
+    `.dynamic { color: red; }`,
+  );
+  await writeFile(join(root, "Card.tsx"), `export const X = () => null;`);
+  const r = await checkCssUnused({
+    rootDir: root,
+    alwaysUsedClasses: ["dynamic"],
+  });
+  expect(r.violations).toEqual([]);
+});
+
+test("passes when every class is referenced from TSX", async () => {
+  await writeFile(
+    join(root, "Card.module.css"),
+    `.a { color: red; }
+.b { color: blue; }`,
+  );
+  await writeFile(
+    join(root, "Card.tsx"),
+    `import s from "./Card.module.css"; export const X = () => <div className={s.a + " " + s.b} />;`,
+  );
+  const r = await checkCssUnused({ rootDir: root });
+  expect(r.violations).toEqual([]);
+});
+
+test("flags a locally-defined variable with no reference", async () => {
+  await writeFile(
+    join(root, "Card.module.css"),
+    `.c {
+  --card-local: 10px;
+  padding: 2px;
+}`,
+  );
+  const r = await checkCssUnused({ rootDir: root });
+  expect(r.violations.some((v) => v.content === "--card-local")).toBe(true);
+});

--- a/tests/unit/quality/css/check-vars.test.ts
+++ b/tests/unit/quality/css/check-vars.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, expect, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, expect, test } from "bun:test";
 import { checkCssVars } from "@fairfox/polly/quality";
 
 let root: string;
@@ -11,26 +11,20 @@ beforeEach(async () => {
 });
 
 test("passes when every var(--x) resolves to a definition", async () => {
-  await writeFile(
-    join(root, "theme.css"),
-    `:root { --polly-text: #111; --polly-surface: #fff; }`,
-  );
+  await writeFile(join(root, "theme.css"), `:root { --polly-text: #111; --polly-surface: #fff; }`);
   await writeFile(
     join(root, "c.module.css"),
-    `.x { color: var(--polly-text); background: var(--polly-surface); }`,
+    `.x { color: var(--polly-text); background: var(--polly-surface); }`
   );
   const r = await checkCssVars({ rootDir: root });
   expect(r.violations).toEqual([]);
 });
 
 test("flags an unknown var reference", async () => {
-  await writeFile(
-    join(root, "theme.css"),
-    `:root { --polly-text: #111; }`,
-  );
+  await writeFile(join(root, "theme.css"), `:root { --polly-text: #111; }`);
   await writeFile(
     join(root, "c.module.css"),
-    `.x { color: var(--polly-text); background: var(--polly-surace); }`,
+    `.x { color: var(--polly-text); background: var(--polly-surace); }`
   );
   const r = await checkCssVars({ rootDir: root });
   expect(r.violations.length).toBe(1);
@@ -38,13 +32,10 @@ test("flags an unknown var reference", async () => {
 });
 
 test("dynamicVars are treated as defined", async () => {
-  await writeFile(
-    join(root, "theme.css"),
-    `:root { --polly-text: #111; }`,
-  );
+  await writeFile(join(root, "theme.css"), `:root { --polly-text: #111; }`);
   await writeFile(
     join(root, "c.module.css"),
-    `.x { --runtime: var(--max-lines); color: var(--polly-text); }`,
+    `.x { --runtime: var(--max-lines); color: var(--polly-text); }`
   );
   const r = await checkCssVars({
     rootDir: root,
@@ -54,13 +45,10 @@ test("dynamicVars are treated as defined", async () => {
 });
 
 test("var references in TS files are also checked", async () => {
-  await writeFile(
-    join(root, "theme.css"),
-    `:root { --polly-text: #111; }`,
-  );
+  await writeFile(join(root, "theme.css"), `:root { --polly-text: #111; }`);
   await writeFile(
     join(root, "Comp.tsx"),
-    `export const X = () => (<div style={{ color: 'var(--polly-missing)' }} />);`,
+    `export const X = () => (<div style={{ color: 'var(--polly-missing)' }} />);`
   );
   const r = await checkCssVars({ rootDir: root });
   expect(r.violations.length).toBe(1);

--- a/tests/unit/quality/css/check-vars.test.ts
+++ b/tests/unit/quality/css/check-vars.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, expect, test } from "bun:test";
+import { checkCssVars } from "@fairfox/polly/quality";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "polly-css-v-"));
+});
+
+test("passes when every var(--x) resolves to a definition", async () => {
+  await writeFile(
+    join(root, "theme.css"),
+    `:root { --polly-text: #111; --polly-surface: #fff; }`,
+  );
+  await writeFile(
+    join(root, "c.module.css"),
+    `.x { color: var(--polly-text); background: var(--polly-surface); }`,
+  );
+  const r = await checkCssVars({ rootDir: root });
+  expect(r.violations).toEqual([]);
+});
+
+test("flags an unknown var reference", async () => {
+  await writeFile(
+    join(root, "theme.css"),
+    `:root { --polly-text: #111; }`,
+  );
+  await writeFile(
+    join(root, "c.module.css"),
+    `.x { color: var(--polly-text); background: var(--polly-surace); }`,
+  );
+  const r = await checkCssVars({ rootDir: root });
+  expect(r.violations.length).toBe(1);
+  expect(r.violations[0]?.content).toContain("--polly-surace");
+});
+
+test("dynamicVars are treated as defined", async () => {
+  await writeFile(
+    join(root, "theme.css"),
+    `:root { --polly-text: #111; }`,
+  );
+  await writeFile(
+    join(root, "c.module.css"),
+    `.x { --runtime: var(--max-lines); color: var(--polly-text); }`,
+  );
+  const r = await checkCssVars({
+    rootDir: root,
+    dynamicVars: ["--max-lines"],
+  });
+  expect(r.violations).toEqual([]);
+});
+
+test("var references in TS files are also checked", async () => {
+  await writeFile(
+    join(root, "theme.css"),
+    `:root { --polly-text: #111; }`,
+  );
+  await writeFile(
+    join(root, "Comp.tsx"),
+    `export const X = () => (<div style={{ color: 'var(--polly-missing)' }} />);`,
+  );
+  const r = await checkCssVars({ rootDir: root });
+  expect(r.violations.length).toBe(1);
+  expect(r.violations[0]?.content).toContain("--polly-missing");
+});

--- a/tests/unit/quality/logger.test.ts
+++ b/tests/unit/quality/logger.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkCssQuality,
+  logger,
+  resetLogger,
+} from "@fairfox/polly/quality";
+
+let root: string;
+let captured: { level: string; message: string }[];
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "polly-logger-"));
+  captured = [];
+  logger.log = (m) => captured.push({ level: "log", message: m });
+  logger.error = (m) => captured.push({ level: "error", message: m });
+  logger.info = (m) => captured.push({ level: "info", message: m });
+  logger.warn = (m) => captured.push({ level: "warn", message: m });
+});
+
+afterEach(() => {
+  resetLogger();
+});
+
+test("logger is mockable — check output is captured", async () => {
+  await writeFile(
+    join(root, "clean.module.css"),
+    `.x { color: var(--polly-text); }`,
+  );
+  const result = await checkCssQuality({ rootDir: root });
+  result.print();
+  expect(captured.length).toBeGreaterThan(0);
+  expect(captured.every((c) => c.level === "log")).toBe(true);
+  expect(captured[0]?.message).toContain("css-quality: no violations");
+});
+
+test("error output goes through logger.error, not console", async () => {
+  await writeFile(
+    join(root, "bad.module.css"),
+    `.x { color: #fff; }`,
+  );
+  const result = await checkCssQuality({ rootDir: root });
+  result.print();
+  const errors = captured.filter((c) => c.level === "error");
+  expect(errors.length).toBeGreaterThan(0);
+  expect(errors[0]?.message).toContain("❌");
+});
+
+test("resetLogger restores the default sinks", async () => {
+  resetLogger();
+  expect(typeof logger.log).toBe("function");
+  expect(typeof logger.error).toBe("function");
+  // After reset, logger.log should no longer be the captured one.
+  const isCapturedFn = logger.log === ((m: string) =>
+    captured.push({ level: "log", message: m }));
+  expect(isCapturedFn).toBe(false);
+});

--- a/tests/unit/quality/logger.test.ts
+++ b/tests/unit/quality/logger.test.ts
@@ -2,11 +2,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  checkCssQuality,
-  logger,
-  resetLogger,
-} from "@fairfox/polly/quality";
+import { checkCssQuality, logger, resetLogger } from "@fairfox/polly/quality";
 
 let root: string;
 let captured: { level: string; message: string }[];
@@ -25,10 +21,7 @@ afterEach(() => {
 });
 
 test("logger is mockable — check output is captured", async () => {
-  await writeFile(
-    join(root, "clean.module.css"),
-    `.x { color: var(--polly-text); }`,
-  );
+  await writeFile(join(root, "clean.module.css"), `.x { color: var(--polly-text); }`);
   const result = await checkCssQuality({ rootDir: root });
   result.print();
   expect(captured.length).toBeGreaterThan(0);
@@ -37,10 +30,7 @@ test("logger is mockable — check output is captured", async () => {
 });
 
 test("error output goes through logger.error, not console", async () => {
-  await writeFile(
-    join(root, "bad.module.css"),
-    `.x { color: #fff; }`,
-  );
+  await writeFile(join(root, "bad.module.css"), `.x { color: #fff; }`);
   const result = await checkCssQuality({ rootDir: root });
   result.print();
   const errors = captured.filter((c) => c.level === "error");
@@ -53,7 +43,6 @@ test("resetLogger restores the default sinks", async () => {
   expect(typeof logger.log).toBe("function");
   expect(typeof logger.error).toBe("function");
   // After reset, logger.log should no longer be the captured one.
-  const isCapturedFn = logger.log === ((m: string) =>
-    captured.push({ level: "log", message: m }));
+  const isCapturedFn = logger.log === ((m: string) => captured.push({ level: "log", message: m }));
   expect(isCapturedFn).toBe(false);
 });

--- a/tests/unit/visual/compare.test.ts
+++ b/tests/unit/visual/compare.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PNG } from "pngjs";
+import { compareImages } from "../../../tools/test/src/visual/compare";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "polly-visual-"));
+});
+
+function writePng(path: string, fill: [number, number, number, number], w = 16, h = 16): void {
+  const png = new PNG({ width: w, height: h });
+  for (let y = 0; y < h; y += 1) {
+    for (let x = 0; x < w; x += 1) {
+      const idx = (y * w + x) * 4;
+      png.data[idx] = fill[0];
+      png.data[idx + 1] = fill[1];
+      png.data[idx + 2] = fill[2];
+      png.data[idx + 3] = fill[3];
+    }
+  }
+  writeFileSync(path, PNG.sync.write(png));
+}
+
+test("identical images match with zero diff pixels", () => {
+  const a = join(root, "a.png");
+  const b = join(root, "b.png");
+  const diff = join(root, "diff.png");
+  writePng(a, [255, 255, 255, 255]);
+  writePng(b, [255, 255, 255, 255]);
+  const r = compareImages(a, b, diff);
+  expect(r.match).toBe(true);
+  expect(r.diffPixels).toBe(0);
+});
+
+test("completely different images fail and emit a diff PNG", () => {
+  const a = join(root, "a.png");
+  const b = join(root, "b.png");
+  const diff = join(root, "diff.png");
+  writePng(a, [0, 0, 0, 255]);
+  writePng(b, [255, 255, 255, 255]);
+  const r = compareImages(a, b, diff);
+  expect(r.match).toBe(false);
+  expect(r.diffPixels).toBeGreaterThan(0);
+  expect(r.diffPngPath).toBe(diff);
+});
+
+test("mismatchRatio tolerates small differences", () => {
+  const a = join(root, "a.png");
+  const b = join(root, "b.png");
+  const diff = join(root, "diff.png");
+  writePng(a, [100, 100, 100, 255]);
+  const png = PNG.sync.read(readFileSync(a));
+  png.data[0] = 255;
+  writeFileSync(b, PNG.sync.write(png));
+  const permissive = compareImages(a, b, diff, {
+    threshold: 0.1,
+    mismatchRatio: 0.01,
+  });
+  expect(permissive.match).toBe(true);
+  const strict = compareImages(a, b, diff, {
+    threshold: 0.1,
+    mismatchRatio: 0,
+  });
+  expect(strict.match).toBe(false);
+});
+
+test("mismatched image dimensions throw", () => {
+  const a = join(root, "a.png");
+  const b = join(root, "b.png");
+  const diff = join(root, "diff.png");
+  writePng(a, [0, 0, 0, 255], 16, 16);
+  writePng(b, [0, 0, 0, 255], 32, 32);
+  expect(() => compareImages(a, b, diff)).toThrow(/dimensions/);
+});

--- a/tools/quality/src/cli.ts
+++ b/tools/quality/src/cli.ts
@@ -26,6 +26,7 @@ import {
   checkCssVars,
   checkNoAsCasting,
 } from "./index";
+import { logger } from "./logger";
 
 const args = process.argv.slice(2);
 
@@ -125,8 +126,8 @@ switch (subcommand) {
     exitCode = await runAll();
     break;
   default:
-    console.error(`Unknown quality subcommand: ${subcommand}`);
-    console.error(
+    logger.error(`Unknown quality subcommand: ${subcommand}`);
+    logger.error(
       "Expected one of: no-as-casting, css, css-quality, css-layout, css-vars, css-unused",
     );
     exitCode = 2;

--- a/tools/quality/src/cli.ts
+++ b/tools/quality/src/cli.ts
@@ -3,14 +3,29 @@
 /**
  * CLI entry point for Polly quality checks.
  *
- *   polly quality [--root <dir>] [--exclude <dirs>] [--pattern <glob>]
- *                 [--exclude-packages <names>] [--exclude-files <names>]
+ *   polly quality                    # run every check
+ *   polly quality no-as-casting      # only the TS casting check
+ *   polly quality css                # all CSS checks
+ *   polly quality css-quality        # only hardcoded-values check
+ *   polly quality css-layout         # only Layout-usage check
+ *   polly quality css-vars           # only undefined-variable check
+ *   polly quality css-unused         # only unused-selector check (advisory)
  *
- * Runs all conformance checks (currently: no-as-casting) against the
- * target directory and exits non-zero when violations are found.
+ * Shared flags:
+ *   --root <dir>                     # defaults to process.cwd()
+ *   --exclude <a,b,c>                # comma-separated dir names
+ *   --exclude-packages <a,b>         # no-as-casting only
+ *   --exclude-files <a,b>            # no-as-casting only
+ *   --pattern <glob>                 # no-as-casting only
  */
 
-import { checkNoAsCasting } from "./no-as-casting";
+import {
+  checkCssLayout,
+  checkCssQuality,
+  checkCssUnused,
+  checkCssVars,
+  checkNoAsCasting,
+} from "./index";
 
 const args = process.argv.slice(2);
 
@@ -19,19 +34,102 @@ function getFlag(name: string): string | undefined {
   return idx >= 0 ? args[idx + 1] : undefined;
 }
 
+function getSubcommand(): string {
+  for (const arg of args) {
+    if (!arg.startsWith("--")) return arg;
+  }
+  return "all";
+}
+
+const subcommand = getSubcommand();
 const rootDir = getFlag("root") ?? process.cwd();
-const exclude = getFlag("exclude")?.split(",") ?? ["node_modules", "dist", ".git", ".bun"];
+const exclude =
+  getFlag("exclude")?.split(",") ??
+  ["node_modules", "dist", ".git", ".bun", "dist-test", "build", "coverage"];
 const excludePackages = getFlag("exclude-packages")?.split(",");
 const excludeFiles = getFlag("exclude-files")?.split(",");
 const filePatterns = getFlag("pattern");
 
-const result = await checkNoAsCasting({
-  rootDir,
-  exclude,
-  ...(excludePackages ? { excludePackages } : {}),
-  ...(excludeFiles ? { excludeFiles } : {}),
-  ...(filePatterns ? { filePatterns } : {}),
-});
+async function runNoAsCasting(): Promise<number> {
+  const result = await checkNoAsCasting({
+    rootDir,
+    exclude,
+    ...(excludePackages ? { excludePackages } : {}),
+    ...(excludeFiles ? { excludeFiles } : {}),
+    ...(filePatterns ? { filePatterns } : {}),
+  });
+  result.print();
+  return result.violations.length > 0 ? 1 : 0;
+}
 
-result.print();
-process.exit(result.violations.length > 0 ? 1 : 0);
+async function runCssQuality(): Promise<number> {
+  const r = await checkCssQuality({ rootDir, skipDirs: exclude });
+  r.print();
+  return r.violations.length > 0 ? 1 : 0;
+}
+
+async function runCssLayout(): Promise<number> {
+  const r = await checkCssLayout({ rootDir, skipDirs: exclude });
+  r.print();
+  return r.violations.length > 0 ? 1 : 0;
+}
+
+async function runCssVars(): Promise<number> {
+  const r = await checkCssVars({ rootDir, skipDirs: exclude });
+  r.print();
+  return r.violations.length > 0 ? 1 : 0;
+}
+
+async function runCssUnused(): Promise<number> {
+  const r = await checkCssUnused({ rootDir, skipDirs: exclude });
+  r.print();
+  return 0;
+}
+
+async function runCssAll(): Promise<number> {
+  const results = [
+    await runCssQuality(),
+    await runCssLayout(),
+    await runCssVars(),
+    await runCssUnused(),
+  ];
+  return results.some((code) => code !== 0) ? 1 : 0;
+}
+
+async function runAll(): Promise<number> {
+  const results = [await runNoAsCasting(), await runCssAll()];
+  return results.some((code) => code !== 0) ? 1 : 0;
+}
+
+let exitCode = 0;
+switch (subcommand) {
+  case "no-as-casting":
+    exitCode = await runNoAsCasting();
+    break;
+  case "css":
+    exitCode = await runCssAll();
+    break;
+  case "css-quality":
+    exitCode = await runCssQuality();
+    break;
+  case "css-layout":
+    exitCode = await runCssLayout();
+    break;
+  case "css-vars":
+    exitCode = await runCssVars();
+    break;
+  case "css-unused":
+    exitCode = await runCssUnused();
+    break;
+  case "all":
+    exitCode = await runAll();
+    break;
+  default:
+    console.error(`Unknown quality subcommand: ${subcommand}`);
+    console.error(
+      "Expected one of: no-as-casting, css, css-quality, css-layout, css-vars, css-unused",
+    );
+    exitCode = 2;
+}
+
+process.exit(exitCode);

--- a/tools/quality/src/cli.ts
+++ b/tools/quality/src/cli.ts
@@ -44,9 +44,15 @@ function getSubcommand(): string {
 
 const subcommand = getSubcommand();
 const rootDir = getFlag("root") ?? process.cwd();
-const exclude =
-  getFlag("exclude")?.split(",") ??
-  ["node_modules", "dist", ".git", ".bun", "dist-test", "build", "coverage"];
+const exclude = getFlag("exclude")?.split(",") ?? [
+  "node_modules",
+  "dist",
+  ".git",
+  ".bun",
+  "dist-test",
+  "build",
+  "coverage",
+];
 const excludePackages = getFlag("exclude-packages")?.split(",");
 const excludeFiles = getFlag("exclude-files")?.split(",");
 const filePatterns = getFlag("pattern");
@@ -128,7 +134,7 @@ switch (subcommand) {
   default:
     logger.error(`Unknown quality subcommand: ${subcommand}`);
     logger.error(
-      "Expected one of: no-as-casting, css, css-quality, css-layout, css-vars, css-unused",
+      "Expected one of: no-as-casting, css, css-quality, css-layout, css-vars, css-unused"
     );
     exitCode = 2;
 }

--- a/tools/quality/src/css/check-layout.ts
+++ b/tools/quality/src/css/check-layout.ts
@@ -9,8 +9,8 @@
  * comment on the violating line or the line above.
  */
 
-import { makeResult, walkDirectory } from "./shared.ts";
 import type { CssCheckResult, CssViolation } from "./shared.ts";
+import { makeResult, walkDirectory } from "./shared.ts";
 
 export type CssLayoutOptions = {
   rootDir: string;
@@ -38,15 +38,14 @@ const TSX_PATTERNS: Array<{ pattern: RegExp; kind: string }> = [
 
 const SUPPRESS = "layout-ignore";
 
-export async function checkCssLayout(
-  options: CssLayoutOptions,
-): Promise<CssCheckResult> {
+export async function checkCssLayout(options: CssLayoutOptions): Promise<CssCheckResult> {
   const rootDir = options.rootDir;
   const exempt = options.layoutExemptPaths ?? ["Layout.module.css", "Layout.tsx"];
   const violations: CssViolation[] = [];
 
   await walkDirectory(
     rootDir,
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: per-file visitor covers filetype, suppression, and pattern loop.
     async (full) => {
       const isCss = full.endsWith(".module.css");
       const isTsx = full.endsWith(".tsx");
@@ -61,11 +60,8 @@ export async function checkCssLayout(
         const line = lines[i];
         if (!line) continue;
         const trimmed = line.trim();
-        if (
-          trimmed.startsWith("//") ||
-          trimmed.startsWith("*") ||
-          trimmed.startsWith("/*")
-        ) continue;
+        if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*"))
+          continue;
         if (trimmed.includes(SUPPRESS)) continue;
         const prev = i > 0 ? (lines[i - 1]?.trim() ?? "") : "";
         if (prev.includes(SUPPRESS)) continue;
@@ -87,7 +83,7 @@ export async function checkCssLayout(
     {
       rootDir,
       skipDirs: options.skipDirs,
-    },
+    }
   );
 
   return makeResult("css-layout", rootDir, violations);

--- a/tools/quality/src/css/check-layout.ts
+++ b/tools/quality/src/css/check-layout.ts
@@ -1,0 +1,94 @@
+/**
+ * CSS layout check.
+ *
+ * `display: flex` and `display: grid` are forbidden outside the Layout
+ * primitive. Apps express layout through the `<Layout>` component so
+ * layout decisions are declarative and greppable. Exempted paths default
+ * to `Layout.module.css`; consumers can extend the list through
+ * `layoutExemptPaths`. Suppress one-off cases with a layout-ignore CSS
+ * comment on the violating line or the line above.
+ */
+
+import { makeResult, walkDirectory } from "./shared.ts";
+import type { CssCheckResult, CssViolation } from "./shared.ts";
+
+export type CssLayoutOptions = {
+  rootDir: string;
+  /** File basenames or path fragments where layout CSS is permitted. */
+  layoutExemptPaths?: string[];
+  /** Directory names skipped during recursion. */
+  skipDirs?: string[];
+};
+
+const CSS_PATTERNS: Array<{ pattern: RegExp; kind: string }> = [
+  { pattern: /display\s*:\s*flex/, kind: "display: flex in CSS" },
+  { pattern: /display\s*:\s*grid/, kind: "display: grid in CSS" },
+];
+
+const TSX_PATTERNS: Array<{ pattern: RegExp; kind: string }> = [
+  {
+    pattern: /display\s*:\s*['"]flex['"]/,
+    kind: "display: flex in inline style",
+  },
+  {
+    pattern: /display\s*:\s*['"]grid['"]/,
+    kind: "display: grid in inline style",
+  },
+];
+
+const SUPPRESS = "layout-ignore";
+
+export async function checkCssLayout(
+  options: CssLayoutOptions,
+): Promise<CssCheckResult> {
+  const rootDir = options.rootDir;
+  const exempt = options.layoutExemptPaths ?? ["Layout.module.css", "Layout.tsx"];
+  const violations: CssViolation[] = [];
+
+  await walkDirectory(
+    rootDir,
+    async (full) => {
+      const isCss = full.endsWith(".module.css");
+      const isTsx = full.endsWith(".tsx");
+      if (!isCss && !isTsx) return;
+      if (exempt.some((fragment) => full.includes(fragment))) return;
+
+      const patterns = isCss ? CSS_PATTERNS : TSX_PATTERNS;
+      const content = await Bun.file(full).text();
+      const lines = content.split("\n");
+
+      for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i];
+        if (!line) continue;
+        const trimmed = line.trim();
+        if (
+          trimmed.startsWith("//") ||
+          trimmed.startsWith("*") ||
+          trimmed.startsWith("/*")
+        ) continue;
+        if (trimmed.includes(SUPPRESS)) continue;
+        const prev = i > 0 ? (lines[i - 1]?.trim() ?? "") : "";
+        if (prev.includes(SUPPRESS)) continue;
+
+        for (const rule of patterns) {
+          if (rule.pattern.test(line)) {
+            violations.push({
+              file: full,
+              line: i + 1,
+              rule: rule.kind,
+              content: trimmed,
+              suggestion: "Use the <Layout> component instead",
+            });
+            break;
+          }
+        }
+      }
+    },
+    {
+      rootDir,
+      skipDirs: options.skipDirs,
+    },
+  );
+
+  return makeResult("css-layout", rootDir, violations);
+}

--- a/tools/quality/src/css/check-quality.ts
+++ b/tools/quality/src/css/check-quality.ts
@@ -10,8 +10,8 @@
  * of a file to skip checks for that file.
  */
 
-import { makeResult, walkDirectory, isInsideComment, isInsideKeyframes } from "./shared.ts";
 import type { CssCheckResult, CssViolation } from "./shared.ts";
+import { isInsideComment, isInsideKeyframes, makeResult, walkDirectory } from "./shared.ts";
 
 export type CssQualityOptions = {
   rootDir: string;
@@ -27,11 +27,7 @@ export type CssQualityOptions = {
 
 type Rule = {
   id: string;
-  check: (
-    line: string,
-    lineNum: number,
-    allLines: readonly string[],
-  ) => string | null;
+  check: (line: string, lineNum: number, allLines: readonly string[]) => string | null;
 };
 
 const DEFAULT_RULES: Rule[] = [
@@ -43,10 +39,7 @@ const DEFAULT_RULES: Rule[] = [
       if (/\bcolor:\s*(white|black|#[0-9a-fA-F]{3,8})\b/.test(line)) {
         return "Use a semantic colour token (--polly-text, --polly-text-muted, …)";
       }
-      if (
-        /background(-color)?:\s*#[0-9a-fA-F]{3,8}/.test(line) &&
-        !line.includes("var(")
-      ) {
+      if (/background(-color)?:\s*#[0-9a-fA-F]{3,8}/.test(line) && !line.includes("var(")) {
         return "Use a semantic surface token (--polly-surface, --polly-surface-raised, …)";
       }
       return null;
@@ -99,9 +92,7 @@ const DEFAULT_RULES: Rule[] = [
       if (line.includes("var(--polly-motion")) return null;
       if (!/(?:transition|animation)/.test(line)) return null;
       if (
-        /\d+(\.\d+)?(ms|s)\s+(ease|linear|ease-in|ease-out|ease-in-out)/.test(
-          line,
-        ) &&
+        /\d+(\.\d+)?(ms|s)\s+(ease|linear|ease-in|ease-out|ease-in-out)/.test(line) &&
         !line.includes("infinite")
       ) {
         return "Use var(--polly-motion-fast|base|slow)";
@@ -139,9 +130,7 @@ const DEFAULT_RULES: Rule[] = [
     check: (line) => {
       if (isInsideComment(line)) return null;
       if (line.includes("var(--polly-border-width")) return null;
-      const m = line.match(
-        /border(?:-(?:top|right|bottom|left))?:\s*(\d+)px\s+solid/,
-      );
+      const m = line.match(/border(?:-(?:top|right|bottom|left))?:\s*(\d+)px\s+solid/);
       if (!m?.[1]) return null;
       return "Use a --polly-border-width-* token";
     },
@@ -179,9 +168,7 @@ const DEFAULT_RULES: Rule[] = [
   },
 ];
 
-export async function checkCssQuality(
-  options: CssQualityOptions,
-): Promise<CssCheckResult> {
+export async function checkCssQuality(options: CssQualityOptions): Promise<CssCheckResult> {
   const rootDir = options.rootDir;
   const extensions = options.extensions ?? [".module.css"];
   const skipFiles = options.skipFiles ?? ["theme.css", "tokens.css"];
@@ -191,6 +178,7 @@ export async function checkCssQuality(
 
   await walkDirectory(
     rootDir,
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: per-file nested rule loop; readable as written.
     async (full) => {
       if (!extensions.some((ext) => full.endsWith(ext))) return;
       const content = await Bun.file(full).text();
@@ -221,7 +209,7 @@ export async function checkCssQuality(
       rootDir,
       skipDirs: options.skipDirs,
       skipFiles,
-    },
+    }
   );
 
   return makeResult("css-quality", rootDir, violations);

--- a/tools/quality/src/css/check-quality.ts
+++ b/tools/quality/src/css/check-quality.ts
@@ -1,0 +1,228 @@
+/**
+ * CSS quality check.
+ *
+ * Every styled value that has a semantic token must reference the token.
+ * Raw hex colours, rgba literals, rem values, numeric font-weights,
+ * magic z-indexes, hardcoded border-radius / border-width / box-shadow,
+ * inline transitions, and `!important` are all rejected. The rule set
+ * is intentionally opinionated; consumers who need an escape hatch may
+ * place a polly-ignore-all marker in a CSS comment on the first line
+ * of a file to skip checks for that file.
+ */
+
+import { makeResult, walkDirectory, isInsideComment, isInsideKeyframes } from "./shared.ts";
+import type { CssCheckResult, CssViolation } from "./shared.ts";
+
+export type CssQualityOptions = {
+  rootDir: string;
+  /** Scan filter — files whose basename ends with one of these are checked. Default: `.module.css`. */
+  extensions?: string[];
+  /** File basenames skipped entirely. Default: `["theme.css", "tokens.css"]`. */
+  skipFiles?: string[];
+  /** Directory names skipped during recursion. */
+  skipDirs?: string[];
+  /** Which rules to disable by id. */
+  disableRules?: string[];
+};
+
+type Rule = {
+  id: string;
+  check: (
+    line: string,
+    lineNum: number,
+    allLines: readonly string[],
+  ) => string | null;
+};
+
+const DEFAULT_RULES: Rule[] = [
+  {
+    id: "no-hardcoded-color",
+    check: (line) => {
+      if (isInsideComment(line)) return null;
+      if (line.includes("var(")) return null;
+      if (/\bcolor:\s*(white|black|#[0-9a-fA-F]{3,8})\b/.test(line)) {
+        return "Use a semantic colour token (--polly-text, --polly-text-muted, …)";
+      }
+      if (
+        /background(-color)?:\s*#[0-9a-fA-F]{3,8}/.test(line) &&
+        !line.includes("var(")
+      ) {
+        return "Use a semantic surface token (--polly-surface, --polly-surface-raised, …)";
+      }
+      return null;
+    },
+  },
+  {
+    id: "no-hardcoded-rgba",
+    check: (line) => {
+      if (isInsideComment(line)) return null;
+      if (!line.includes("rgba(")) return null;
+      if (line.includes("var(")) return null;
+      if (line.includes("color-mix(")) return null;
+      if (/background.*rgba/.test(line)) {
+        return "Use a semantic surface or overlay token";
+      }
+      if (/box-shadow.*rgba/.test(line)) {
+        return "Use a semantic shadow token";
+      }
+      return "Use a semantic token instead of raw rgba()";
+    },
+  },
+  {
+    id: "no-hardcoded-z-index",
+    check: (line) => {
+      const m = line.match(/z-index:\s*(\d+)/);
+      if (!m?.[1]) return null;
+      if (line.includes("var(")) return null;
+      if (Number.parseInt(m[1], 10) < 10) return null;
+      return "Use a --polly-z-* token";
+    },
+  },
+  {
+    id: "no-hardcoded-opacity",
+    check: (line) => {
+      if (!/opacity:\s*0\.\d/.test(line)) return null;
+      if (line.includes("var(")) return null;
+      const m = line.match(/opacity:\s*(0\.\d+)/);
+      if (!m?.[1]) return null;
+      const v = Number.parseFloat(m[1]);
+      if (v >= 0.5 && v <= 0.7) {
+        return "Use var(--polly-opacity-disabled) for disabled states";
+      }
+      return null;
+    },
+  },
+  {
+    id: "no-hardcoded-transition",
+    check: (line, lineNum, allLines) => {
+      if (isInsideKeyframes(lineNum, allLines)) return null;
+      if (line.includes("var(--polly-motion")) return null;
+      if (!/(?:transition|animation)/.test(line)) return null;
+      if (
+        /\d+(\.\d+)?(ms|s)\s+(ease|linear|ease-in|ease-out|ease-in-out)/.test(
+          line,
+        ) &&
+        !line.includes("infinite")
+      ) {
+        return "Use var(--polly-motion-fast|base|slow)";
+      }
+      if (/\s\d+(\.\d+)?s[;\s,]/.test(line) && !line.includes("infinite")) {
+        return "Use var(--polly-motion-fast|base|slow)";
+      }
+      return null;
+    },
+  },
+  {
+    id: "no-important",
+    check: (line) => {
+      if (isInsideComment(line)) return null;
+      if (!line.includes("!important")) return null;
+      return "Refactor specificity instead of using !important";
+    },
+  },
+  {
+    id: "no-rem-units",
+    check: (line, lineNum, allLines) => {
+      if (isInsideComment(line)) return null;
+      if (isInsideKeyframes(lineNum, allLines)) return null;
+      if (/:\s*[^;]*\d+(\.\d+)?rem[;\s]/.test(line)) {
+        if (line.includes("calc(") || line.includes("translateY(")) {
+          return null;
+        }
+        return "Use --polly-space-* or --polly-text-* tokens instead of rem";
+      }
+      return null;
+    },
+  },
+  {
+    id: "no-hardcoded-border-width",
+    check: (line) => {
+      if (isInsideComment(line)) return null;
+      if (line.includes("var(--polly-border-width")) return null;
+      const m = line.match(
+        /border(?:-(?:top|right|bottom|left))?:\s*(\d+)px\s+solid/,
+      );
+      if (!m?.[1]) return null;
+      return "Use a --polly-border-width-* token";
+    },
+  },
+  {
+    id: "no-hardcoded-border-radius",
+    check: (line) => {
+      if (isInsideComment(line)) return null;
+      if (line.includes("var(")) return null;
+      const m = line.match(/border-radius:\s*(\d+)px/);
+      if (!m?.[1]) return null;
+      if (m[1] === "0") return null;
+      return "Use a --polly-radius-{sm,md,lg} token";
+    },
+  },
+  {
+    id: "no-hardcoded-box-shadow",
+    check: (line) => {
+      if (isInsideComment(line)) return null;
+      if (!line.includes("box-shadow:")) return null;
+      if (line.includes("var(--polly-shadow")) return null;
+      if (line.includes("var(--polly-focus-ring")) return null;
+      if (line.includes("var(")) return null;
+      if (/box-shadow:\s*none/.test(line)) return null;
+      return "Use var(--polly-shadow-*) or var(--polly-focus-ring)";
+    },
+  },
+  {
+    id: "no-hardcoded-font-weight",
+    check: (line) => {
+      if (!/font-weight:\s*\d{3}/.test(line)) return null;
+      if (line.includes("var(")) return null;
+      return "Use var(--polly-weight-normal|medium|bold)";
+    },
+  },
+];
+
+export async function checkCssQuality(
+  options: CssQualityOptions,
+): Promise<CssCheckResult> {
+  const rootDir = options.rootDir;
+  const extensions = options.extensions ?? [".module.css"];
+  const skipFiles = options.skipFiles ?? ["theme.css", "tokens.css"];
+  const disabled = new Set(options.disableRules ?? []);
+  const rules = DEFAULT_RULES.filter((r) => !disabled.has(r.id));
+  const violations: CssViolation[] = [];
+
+  await walkDirectory(
+    rootDir,
+    async (full) => {
+      if (!extensions.some((ext) => full.endsWith(ext))) return;
+      const content = await Bun.file(full).text();
+      const lines = content.split("\n");
+      const hasFileIgnore = lines[0]?.includes("polly-ignore-all");
+      if (hasFileIgnore) return;
+
+      for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i];
+        if (!line) continue;
+        const trimmed = line.trim();
+        if (trimmed === "" || trimmed === "{" || trimmed === "}") continue;
+        for (const rule of rules) {
+          const suggestion = rule.check(line, i, lines);
+          if (suggestion) {
+            violations.push({
+              file: full,
+              line: i + 1,
+              rule: rule.id,
+              content: trimmed,
+              suggestion,
+            });
+          }
+        }
+      }
+    },
+    {
+      rootDir,
+      skipDirs: options.skipDirs,
+      skipFiles,
+    },
+  );
+
+  return makeResult("css-quality", rootDir, violations);
+}

--- a/tools/quality/src/css/check-unused.ts
+++ b/tools/quality/src/css/check-unused.ts
@@ -1,0 +1,146 @@
+/**
+ * Unused CSS detection (advisory).
+ *
+ * Finds classes and locally-defined custom properties in `.module.css`
+ * files that appear to have no reference. Classes are checked against
+ * every `.ts` / `.tsx` file's textual content; variables are checked
+ * against other CSS files plus JS/TS referencing the same `--name`.
+ * Matching is string-based and cannot see through dynamic lookups —
+ * so this check is advisory only. Violations are returned as warnings;
+ * the caller decides whether to fail the build.
+ */
+
+import { makeResult, walkDirectory } from "./shared.ts";
+import type { CssCheckResult, CssViolation } from "./shared.ts";
+
+export type CssUnusedOptions = {
+  rootDir: string;
+  /** Directory names skipped during recursion. */
+  skipDirs?: string[];
+  /** Class names treated as always-used (e.g. framework-generated). */
+  alwaysUsedClasses?: string[];
+};
+
+type Definition = {
+  file: string;
+  name: string;
+  line: number;
+  type: "class" | "variable";
+};
+
+export async function checkCssUnused(
+  options: CssUnusedOptions,
+): Promise<CssCheckResult> {
+  const rootDir = options.rootDir;
+  const alwaysUsed = new Set(options.alwaysUsedClasses ?? []);
+  const definitions: Definition[] = [];
+  const tsContents: Array<{ file: string; content: string }> = [];
+  const cssContents: Array<{ file: string; content: string }> = [];
+
+  await walkDirectory(
+    rootDir,
+    async (full) => {
+      if (full.endsWith(".module.css")) {
+        const content = await Bun.file(full).text();
+        const lines = content.split("\n");
+        for (let i = 0; i < lines.length; i += 1) {
+          const line = lines[i];
+          if (!line) continue;
+          for (const m of line.matchAll(/(?:^|[\s,>+~])\.([\w-]+)/g)) {
+            if (m[1]) {
+              definitions.push({
+                file: full,
+                name: m[1],
+                line: i + 1,
+                type: "class",
+              });
+            }
+          }
+          for (const m of line.matchAll(/^\s+--([\w-]+)\s*:/g)) {
+            if (m[1]) {
+              definitions.push({
+                file: full,
+                name: `--${m[1]}`,
+                line: i + 1,
+                type: "variable",
+              });
+            }
+          }
+        }
+        cssContents.push({ file: full, content });
+      } else if (full.endsWith(".css") && !full.endsWith(".css.d.ts")) {
+        const content = await Bun.file(full).text();
+        cssContents.push({ file: full, content });
+      } else if (
+        (full.endsWith(".ts") || full.endsWith(".tsx")) &&
+        !full.endsWith(".css.d.ts")
+      ) {
+        const content = await Bun.file(full).text();
+        tsContents.push({ file: full, content });
+      }
+    },
+    { rootDir, skipDirs: options.skipDirs },
+  );
+
+  // Deduplicate definitions (same class may appear in multiple selectors)
+  const seen = new Set<string>();
+  const uniqueDefs = definitions.filter((d) => {
+    const key = `${d.file}:${d.type}:${d.name}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  function classReferenced(name: string): boolean {
+    if (alwaysUsed.has(name)) return true;
+    for (const { content } of tsContents) {
+      if (
+        content.includes(`.${name}`) ||
+        content.includes(`['${name}']`) ||
+        content.includes(`["${name}"]`)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function variableReferenced(name: string, defFile: string): boolean {
+    for (const { file, content } of cssContents) {
+      if (file === defFile) continue;
+      if (content.includes(`var(${name})`)) return true;
+    }
+    const self = cssContents.find((f) => f.file === defFile);
+    if (self) {
+      const occurrences = self.content.split(name).length - 1;
+      if (occurrences > 1) return true;
+    }
+    for (const { content } of tsContents) {
+      if (content.includes(name)) return true;
+    }
+    return false;
+  }
+
+  const violations: CssViolation[] = [];
+  for (const def of uniqueDefs) {
+    if (def.type === "class" && !classReferenced(def.name)) {
+      violations.push({
+        file: def.file,
+        line: def.line,
+        rule: "unused-class",
+        content: `.${def.name}`,
+        suggestion: "Delete the selector or reference the class from a component",
+      });
+    } else if (def.type === "variable" && !variableReferenced(def.name, def.file)) {
+      violations.push({
+        file: def.file,
+        line: def.line,
+        rule: "unused-variable",
+        content: def.name,
+        suggestion: "Delete the definition or reference the variable",
+      });
+    }
+  }
+
+  return makeResult("css-unused (advisory)", rootDir, violations);
+}

--- a/tools/quality/src/css/check-unused.ts
+++ b/tools/quality/src/css/check-unused.ts
@@ -10,8 +10,8 @@
  * the caller decides whether to fail the build.
  */
 
-import { makeResult, walkDirectory } from "./shared.ts";
 import type { CssCheckResult, CssViolation } from "./shared.ts";
+import { makeResult, walkDirectory } from "./shared.ts";
 
 export type CssUnusedOptions = {
   rootDir: string;
@@ -28,9 +28,7 @@ type Definition = {
   type: "class" | "variable";
 };
 
-export async function checkCssUnused(
-  options: CssUnusedOptions,
-): Promise<CssCheckResult> {
+export async function checkCssUnused(options: CssUnusedOptions): Promise<CssCheckResult> {
   const rootDir = options.rootDir;
   const alwaysUsed = new Set(options.alwaysUsedClasses ?? []);
   const definitions: Definition[] = [];
@@ -39,6 +37,7 @@ export async function checkCssUnused(
 
   await walkDirectory(
     rootDir,
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: filetype dispatch with nested matchAll scans; flat branches.
     async (full) => {
       if (full.endsWith(".module.css")) {
         const content = await Bun.file(full).text();
@@ -71,15 +70,12 @@ export async function checkCssUnused(
       } else if (full.endsWith(".css") && !full.endsWith(".css.d.ts")) {
         const content = await Bun.file(full).text();
         cssContents.push({ file: full, content });
-      } else if (
-        (full.endsWith(".ts") || full.endsWith(".tsx")) &&
-        !full.endsWith(".css.d.ts")
-      ) {
+      } else if ((full.endsWith(".ts") || full.endsWith(".tsx")) && !full.endsWith(".css.d.ts")) {
         const content = await Bun.file(full).text();
         tsContents.push({ file: full, content });
       }
     },
-    { rootDir, skipDirs: options.skipDirs },
+    { rootDir, skipDirs: options.skipDirs }
   );
 
   // Deduplicate definitions (same class may appear in multiple selectors)
@@ -105,6 +101,7 @@ export async function checkCssUnused(
     return false;
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: three-way reference check (other CSS, same CSS self-count, TS references).
   function variableReferenced(name: string, defFile: string): boolean {
     for (const { file, content } of cssContents) {
       if (file === defFile) continue;

--- a/tools/quality/src/css/check-vars.ts
+++ b/tools/quality/src/css/check-vars.ts
@@ -1,0 +1,77 @@
+/**
+ * CSS variable reference validator.
+ *
+ * Two-pass scanner. First pass collects every `--name:` definition in
+ * every `.css` file under the root. Second pass walks `.css`, `.ts`, and
+ * `.tsx` files and reports any `var(--name)` that does not resolve. Catches
+ * typos, stale references, and references to removed tokens.
+ *
+ * Variables that are set via JS (inline style) can be declared via
+ * `dynamicVars` so they are treated as defined without appearing in CSS.
+ */
+
+import { makeResult, walkDirectory } from "./shared.ts";
+import type { CssCheckResult, CssViolation } from "./shared.ts";
+
+export type CssVarsOptions = {
+  rootDir: string;
+  /** Extensions scanned for var(--x) references. Default: css, ts, tsx. */
+  scanExtensions?: string[];
+  /** Variables defined dynamically (set via JS). Treated as defined. */
+  dynamicVars?: string[];
+  /** Directory names skipped during recursion. */
+  skipDirs?: string[];
+};
+
+export async function checkCssVars(
+  options: CssVarsOptions,
+): Promise<CssCheckResult> {
+  const rootDir = options.rootDir;
+  const scanExts = options.scanExtensions ?? [".ts", ".tsx", ".css"];
+  const dynamic = new Set(options.dynamicVars ?? []);
+  const definitions = new Set<string>(dynamic);
+  const violations: CssViolation[] = [];
+
+  // Pass 1 — collect all CSS custom property definitions
+  await walkDirectory(
+    rootDir,
+    async (full) => {
+      if (!full.endsWith(".css")) return;
+      const content = await Bun.file(full).text();
+      for (const m of content.matchAll(/--([\w-]+)\s*:/g)) {
+        if (m[1]) definitions.add(`--${m[1]}`);
+      }
+    },
+    { rootDir, skipDirs: options.skipDirs },
+  );
+
+  // Pass 2 — scan var(--name) references
+  await walkDirectory(
+    rootDir,
+    async (full) => {
+      if (full.endsWith(".css.d.ts")) return;
+      if (!scanExts.some((ext) => full.endsWith(ext))) return;
+      const content = await Bun.file(full).text();
+      const lines = content.split("\n");
+      for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i];
+        if (!line) continue;
+        for (const m of line.matchAll(/var\(--([\w-]+)\)/g)) {
+          const name = `--${m[1]}`;
+          if (!definitions.has(name)) {
+            violations.push({
+              file: full,
+              line: i + 1,
+              rule: "undefined-var",
+              content: line.trim(),
+              suggestion: `Define ${name} in a CSS file or add to dynamicVars`,
+            });
+          }
+        }
+      }
+    },
+    { rootDir, skipDirs: options.skipDirs },
+  );
+
+  return makeResult("css-vars", rootDir, violations);
+}

--- a/tools/quality/src/css/check-vars.ts
+++ b/tools/quality/src/css/check-vars.ts
@@ -10,8 +10,8 @@
  * `dynamicVars` so they are treated as defined without appearing in CSS.
  */
 
-import { makeResult, walkDirectory } from "./shared.ts";
 import type { CssCheckResult, CssViolation } from "./shared.ts";
+import { makeResult, walkDirectory } from "./shared.ts";
 
 export type CssVarsOptions = {
   rootDir: string;
@@ -23,9 +23,7 @@ export type CssVarsOptions = {
   skipDirs?: string[];
 };
 
-export async function checkCssVars(
-  options: CssVarsOptions,
-): Promise<CssCheckResult> {
+export async function checkCssVars(options: CssVarsOptions): Promise<CssCheckResult> {
   const rootDir = options.rootDir;
   const scanExts = options.scanExtensions ?? [".ts", ".tsx", ".css"];
   const dynamic = new Set(options.dynamicVars ?? []);
@@ -42,12 +40,13 @@ export async function checkCssVars(
         if (m[1]) definitions.add(`--${m[1]}`);
       }
     },
-    { rootDir, skipDirs: options.skipDirs },
+    { rootDir, skipDirs: options.skipDirs }
   );
 
   // Pass 2 — scan var(--name) references
   await walkDirectory(
     rootDir,
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: nested for + matchAll per file is linear and readable as written.
     async (full) => {
       if (full.endsWith(".css.d.ts")) return;
       if (!scanExts.some((ext) => full.endsWith(ext))) return;
@@ -70,7 +69,7 @@ export async function checkCssVars(
         }
       }
     },
-    { rootDir, skipDirs: options.skipDirs },
+    { rootDir, skipDirs: options.skipDirs }
   );
 
   return makeResult("css-vars", rootDir, violations);

--- a/tools/quality/src/css/shared.ts
+++ b/tools/quality/src/css/shared.ts
@@ -32,24 +32,18 @@ export type CssScanOptions = {
   skipFiles?: string[];
 };
 
-export const DEFAULT_SKIP_DIRS = [
-  "node_modules",
-  ".git",
-  "dist",
-  "dist-test",
-  "build",
-  "coverage",
-];
+export const DEFAULT_SKIP_DIRS = ["node_modules", ".git", "dist", "dist-test", "build", "coverage"];
 
 export async function walkDirectory(
   dir: string,
   visit: (filePath: string, relPath: string) => Promise<void>,
-  opts: CssScanOptions,
+  opts: CssScanOptions
 ): Promise<void> {
   const skipDirs = new Set(opts.skipDirs ?? DEFAULT_SKIP_DIRS);
   const skipFiles = new Set(opts.skipFiles ?? []);
   const rootDir = opts.rootDir;
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: recursive walk with skip sets is inherently branchy.
   async function walk(current: string): Promise<void> {
     let entries: Dirent[];
     try {
@@ -76,7 +70,7 @@ export async function walkDirectory(
 export function formatViolations(
   kind: string,
   violations: CssViolation[],
-  rootDir: string,
+  rootDir: string
 ): string[] {
   const lines: string[] = [];
   if (violations.length === 0) {
@@ -100,7 +94,11 @@ export function formatViolations(
   return lines;
 }
 
-export function makeResult(kind: string, rootDir: string, violations: CssViolation[]): CssCheckResult {
+export function makeResult(
+  kind: string,
+  rootDir: string,
+  violations: CssViolation[]
+): CssCheckResult {
   return {
     violations,
     print() {
@@ -118,18 +116,11 @@ export function makeResult(kind: string, rootDir: string, violations: CssViolati
 /** True when the line is a CSS comment (standalone or continuation). */
 export function isInsideComment(line: string): boolean {
   const trimmed = line.trim();
-  return (
-    trimmed.startsWith("/*") ||
-    trimmed.startsWith("*") ||
-    trimmed.startsWith("//")
-  );
+  return trimmed.startsWith("/*") || trimmed.startsWith("*") || trimmed.startsWith("//");
 }
 
 /** Heuristic: true when the given line number falls inside an @keyframes block. */
-export function isInsideKeyframes(
-  lineNum: number,
-  allLines: readonly string[],
-): boolean {
+export function isInsideKeyframes(lineNum: number, allLines: readonly string[]): boolean {
   for (let i = lineNum - 1; i >= 0; i -= 1) {
     const l = allLines[i]?.trim() ?? "";
     if (l.startsWith("@keyframes")) return true;

--- a/tools/quality/src/css/shared.ts
+++ b/tools/quality/src/css/shared.ts
@@ -9,6 +9,7 @@
 import type { Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join, relative } from "node:path";
+import { logger } from "../logger.ts";
 
 export type CssViolation = {
   file: string;
@@ -105,9 +106,9 @@ export function makeResult(kind: string, rootDir: string, violations: CssViolati
     print() {
       for (const line of formatViolations(kind, violations, rootDir)) {
         if (line.startsWith("❌")) {
-          console.error(line);
+          logger.error(line);
         } else {
-          console.log(line);
+          logger.log(line);
         }
       }
     },

--- a/tools/quality/src/css/shared.ts
+++ b/tools/quality/src/css/shared.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared plumbing for CSS conformance checks.
+ *
+ * File discovery, violation printing, and common scanner options live
+ * here so each check (`quality`, `layout`, `vars`, `unused`) can stay
+ * focused on its own rule set.
+ */
+
+import type { Dirent } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+export type CssViolation = {
+  file: string;
+  line: number;
+  rule: string;
+  content: string;
+  suggestion: string;
+};
+
+export type CssCheckResult = {
+  violations: CssViolation[];
+  print: () => void;
+};
+
+export type CssScanOptions = {
+  rootDir: string;
+  /** Directory names (not paths) to skip during recursion. */
+  skipDirs?: string[];
+  /** File names (not paths) to skip entirely. */
+  skipFiles?: string[];
+};
+
+export const DEFAULT_SKIP_DIRS = [
+  "node_modules",
+  ".git",
+  "dist",
+  "dist-test",
+  "build",
+  "coverage",
+];
+
+export async function walkDirectory(
+  dir: string,
+  visit: (filePath: string, relPath: string) => Promise<void>,
+  opts: CssScanOptions,
+): Promise<void> {
+  const skipDirs = new Set(opts.skipDirs ?? DEFAULT_SKIP_DIRS);
+  const skipFiles = new Set(opts.skipFiles ?? []);
+  const rootDir = opts.rootDir;
+
+  async function walk(current: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (skipDirs.has(entry.name)) continue;
+        await walk(full);
+      } else if (entry.isFile()) {
+        if (skipFiles.has(entry.name)) continue;
+        const rel = relative(rootDir, full);
+        await visit(full, rel);
+      }
+    }
+  }
+
+  await walk(dir);
+}
+
+export function formatViolations(
+  kind: string,
+  violations: CssViolation[],
+  rootDir: string,
+): string[] {
+  const lines: string[] = [];
+  if (violations.length === 0) {
+    lines.push(`✅ ${kind}: no violations`);
+    return lines;
+  }
+  lines.push(`❌ ${kind}: ${violations.length} violation(s)`);
+  const byFile = new Map<string, CssViolation[]>();
+  for (const v of violations) {
+    const bucket = byFile.get(v.file) ?? [];
+    bucket.push(v);
+    byFile.set(v.file, bucket);
+  }
+  for (const [file, fileViolations] of byFile) {
+    lines.push(`  ${relative(rootDir, file)}`);
+    for (const v of fileViolations) {
+      lines.push(`    L${v.line}: ${v.content}`);
+      lines.push(`          → ${v.suggestion} [${v.rule}]`);
+    }
+  }
+  return lines;
+}
+
+export function makeResult(kind: string, rootDir: string, violations: CssViolation[]): CssCheckResult {
+  return {
+    violations,
+    print() {
+      for (const line of formatViolations(kind, violations, rootDir)) {
+        if (line.startsWith("❌")) {
+          console.error(line);
+        } else {
+          console.log(line);
+        }
+      }
+    },
+  };
+}
+
+/** True when the line is a CSS comment (standalone or continuation). */
+export function isInsideComment(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("//")
+  );
+}
+
+/** Heuristic: true when the given line number falls inside an @keyframes block. */
+export function isInsideKeyframes(
+  lineNum: number,
+  allLines: readonly string[],
+): boolean {
+  for (let i = lineNum - 1; i >= 0; i -= 1) {
+    const l = allLines[i]?.trim() ?? "";
+    if (l.startsWith("@keyframes")) return true;
+    if (l === "}" && i < lineNum - 1) return false;
+  }
+  return false;
+}

--- a/tools/quality/src/index.ts
+++ b/tools/quality/src/index.ts
@@ -48,3 +48,8 @@ export {
 export { checkCssVars, type CssVarsOptions } from "./css/check-vars.ts";
 export { checkCssUnused, type CssUnusedOptions } from "./css/check-unused.ts";
 export type { CssCheckResult, CssViolation } from "./css/shared.ts";
+export {
+  logger,
+  type QualityLogger,
+  resetLogger,
+} from "./logger.ts";

--- a/tools/quality/src/index.ts
+++ b/tools/quality/src/index.ts
@@ -30,26 +30,26 @@
  */
 
 export {
-  type CheckResult,
-  checkNoAsCasting,
-  isLineClean,
-  suggestFix,
-  type Violation,
-} from "./no-as-casting";
+  type CssLayoutOptions,
+  checkCssLayout,
+} from "./css/check-layout.ts";
 
 export {
-  checkCssQuality,
   type CssQualityOptions,
+  checkCssQuality,
 } from "./css/check-quality.ts";
-export {
-  checkCssLayout,
-  type CssLayoutOptions,
-} from "./css/check-layout.ts";
-export { checkCssVars, type CssVarsOptions } from "./css/check-vars.ts";
-export { checkCssUnused, type CssUnusedOptions } from "./css/check-unused.ts";
+export { type CssUnusedOptions, checkCssUnused } from "./css/check-unused.ts";
+export { type CssVarsOptions, checkCssVars } from "./css/check-vars.ts";
 export type { CssCheckResult, CssViolation } from "./css/shared.ts";
 export {
   logger,
   type QualityLogger,
   resetLogger,
 } from "./logger.ts";
+export {
+  type CheckResult,
+  checkNoAsCasting,
+  isLineClean,
+  suggestFix,
+  type Violation,
+} from "./no-as-casting";

--- a/tools/quality/src/index.ts
+++ b/tools/quality/src/index.ts
@@ -7,6 +7,12 @@
  * applications wire it into their own CI or pre-commit hook via the
  * companion `checkNoAsCasting` runner.
  *
+ * The CSS conformance family — `checkCssQuality`, `checkCssLayout`,
+ * `checkCssVars`, `checkCssUnused` — enforces the token-driven styling
+ * contract that @fairfox/polly/ui ships: all styled values go through
+ * semantic tokens, layout goes through the `<Layout>` primitive, no
+ * variable references dangle, and unused selectors are surfaced.
+ *
  * @example
  * ```typescript
  * import { checkNoAsCasting } from "@fairfox/polly/quality";
@@ -30,3 +36,15 @@ export {
   suggestFix,
   type Violation,
 } from "./no-as-casting";
+
+export {
+  checkCssQuality,
+  type CssQualityOptions,
+} from "./css/check-quality.ts";
+export {
+  checkCssLayout,
+  type CssLayoutOptions,
+} from "./css/check-layout.ts";
+export { checkCssVars, type CssVarsOptions } from "./css/check-vars.ts";
+export { checkCssUnused, type CssUnusedOptions } from "./css/check-unused.ts";
+export type { CssCheckResult, CssViolation } from "./css/shared.ts";

--- a/tools/quality/src/logger.ts
+++ b/tools/quality/src/logger.ts
@@ -25,16 +25,18 @@ export type QualityLogger = {
 };
 
 function defaultLog(message: string): void {
-  // biome-ignore lint/suspicious/noConsoleLog: CLI output by design
   console.log(message);
 }
 function defaultError(message: string): void {
+  // biome-ignore lint/suspicious/noConsole: CLI output is the whole point of the default sink.
   console.error(message);
 }
 function defaultInfo(message: string): void {
+  // biome-ignore lint/suspicious/noConsole: CLI output is the whole point of the default sink.
   console.info(message);
 }
 function defaultWarn(message: string): void {
+  // biome-ignore lint/suspicious/noConsole: CLI output is the whole point of the default sink.
   console.warn(message);
 }
 

--- a/tools/quality/src/logger.ts
+++ b/tools/quality/src/logger.ts
@@ -1,0 +1,53 @@
+/**
+ * Logger for the quality tool.
+ *
+ * One mutable singleton so every check writes through the same sink.
+ * Tests replace the methods to capture output, then call `resetLogger()`
+ * to restore defaults. No dependency injection chain through every
+ * check signature — the singleton pattern matches how Polly's own
+ * CLI output is consumed (stdout/stderr at process edge).
+ *
+ *   import { logger, resetLogger } from "./logger";
+ *   logger.error("…");
+ *
+ *   // in tests
+ *   const captured: string[] = [];
+ *   logger.error = (m) => captured.push(m);
+ *   // ... run check ...
+ *   resetLogger();
+ */
+
+export type QualityLogger = {
+  log: (message: string) => void;
+  error: (message: string) => void;
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+function defaultLog(message: string): void {
+  // biome-ignore lint/suspicious/noConsoleLog: CLI output by design
+  console.log(message);
+}
+function defaultError(message: string): void {
+  console.error(message);
+}
+function defaultInfo(message: string): void {
+  console.info(message);
+}
+function defaultWarn(message: string): void {
+  console.warn(message);
+}
+
+export const logger: QualityLogger = {
+  log: defaultLog,
+  error: defaultError,
+  info: defaultInfo,
+  warn: defaultWarn,
+};
+
+export function resetLogger(): void {
+  logger.log = defaultLog;
+  logger.error = defaultError;
+  logger.info = defaultInfo;
+  logger.warn = defaultWarn;
+}

--- a/tools/quality/src/no-as-casting.ts
+++ b/tools/quality/src/no-as-casting.ts
@@ -14,6 +14,7 @@
 
 import { readFileSync } from "node:fs";
 import { Glob } from "bun";
+import { logger } from "./logger";
 
 export interface Violation {
   file: string;
@@ -240,18 +241,18 @@ function findViolations(relative: string, content: string): Violation[] {
 
 function printViolations(violations: Violation[]): void {
   if (violations.length === 0) {
-    console.log("[no-as-casting] ✅ No violations found.");
+    logger.log("[no-as-casting] ✅ No violations found.");
     return;
   }
-  console.log(`[no-as-casting] ❌ ${violations.length} violation(s) found:\n`);
+  logger.log(`[no-as-casting] ❌ ${violations.length} violation(s) found:\n`);
   for (const v of violations) {
-    console.log(`  ${v.file}:${v.line}`);
-    console.log(`    ${v.content}`);
-    if (v.advice) console.log(`    💡 ${v.advice}`);
-    console.log();
+    logger.log(`  ${v.file}:${v.line}`);
+    logger.log(`    ${v.content}`);
+    if (v.advice) logger.log(`    💡 ${v.advice}`);
+    logger.log("");
   }
-  console.log("[no-as-casting] Use type guards, validation, or fix the types at the source.");
-  console.log('[no-as-casting] Only "as const" and "as unknown as" are allowed.');
+  logger.log("[no-as-casting] Use type guards, validation, or fix the types at the source.");
+  logger.log('[no-as-casting] Only "as const" and "as unknown as" are allowed.');
 }
 
 /**

--- a/tools/test/src/browser/run.ts
+++ b/tools/test/src/browser/run.ts
@@ -56,7 +56,7 @@ const testDir = resolve(process.cwd(), process.argv[2] ?? "tests/browser");
 const filter = process.argv[3] ?? "";
 const headless = process.env["HEADLESS"] !== "false";
 
-const glob = new Glob("**/*.browser.ts");
+const glob = new Glob("**/*.browser.{ts,tsx}");
 const testFiles: string[] = [];
 for await (const file of glob.scan({ cwd: testDir, absolute: true })) {
   if (file.includes("harness")) continue;

--- a/tools/test/src/visual/compare.ts
+++ b/tools/test/src/visual/compare.ts
@@ -31,7 +31,7 @@ export function compareImages(
   baselinePath: string,
   actualPath: string,
   diffPath: string,
-  options: VisualCompareOptions = {},
+  options: VisualCompareOptions = {}
 ): VisualCompareResult {
   const threshold = options.threshold ?? 0.1;
   const mismatchRatio = options.mismatchRatio ?? 0.001;
@@ -42,20 +42,16 @@ export function compareImages(
 
   if (baseline.width !== actual.width || baseline.height !== actual.height) {
     throw new Error(
-      `Image dimensions differ: baseline ${baseline.width}x${baseline.height}, actual ${actual.width}x${actual.height}`,
+      `Image dimensions differ: baseline ${baseline.width}x${baseline.height}, actual ${actual.width}x${actual.height}`
     );
   }
 
   const { width, height } = baseline;
   const diff = new PNG({ width, height });
-  const diffPixels = pixelmatch(
-    baseline.data,
-    actual.data,
-    diff.data,
-    width,
-    height,
-    { threshold, includeAA },
-  );
+  const diffPixels = pixelmatch(baseline.data, actual.data, diff.data, width, height, {
+    threshold,
+    includeAA,
+  });
 
   const totalPixels = width * height;
   const ratio = diffPixels / totalPixels;

--- a/tools/test/src/visual/compare.ts
+++ b/tools/test/src/visual/compare.ts
@@ -1,0 +1,71 @@
+/**
+ * PNG comparison via pixelmatch.
+ *
+ * Returns the number of differing pixels and the mismatch ratio against
+ * a tolerance. Emits a diff PNG on failure so the author can see which
+ * region changed.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+
+export type VisualCompareOptions = {
+  /** Pixel-level colour tolerance (0..1). Default 0.1 — per pixel diff threshold. */
+  threshold?: number;
+  /** Max differing pixels allowed as a ratio of total pixels. Default 0.001. */
+  mismatchRatio?: number;
+  /** When true, includes anti-aliased pixels in the count. Default false. */
+  includeAA?: boolean;
+};
+
+export type VisualCompareResult = {
+  match: boolean;
+  diffPixels: number;
+  totalPixels: number;
+  ratio: number;
+  diffPngPath?: string;
+};
+
+export function compareImages(
+  baselinePath: string,
+  actualPath: string,
+  diffPath: string,
+  options: VisualCompareOptions = {},
+): VisualCompareResult {
+  const threshold = options.threshold ?? 0.1;
+  const mismatchRatio = options.mismatchRatio ?? 0.001;
+  const includeAA = options.includeAA ?? false;
+
+  const baseline = PNG.sync.read(readFileSync(baselinePath));
+  const actual = PNG.sync.read(readFileSync(actualPath));
+
+  if (baseline.width !== actual.width || baseline.height !== actual.height) {
+    throw new Error(
+      `Image dimensions differ: baseline ${baseline.width}x${baseline.height}, actual ${actual.width}x${actual.height}`,
+    );
+  }
+
+  const { width, height } = baseline;
+  const diff = new PNG({ width, height });
+  const diffPixels = pixelmatch(
+    baseline.data,
+    actual.data,
+    diff.data,
+    width,
+    height,
+    { threshold, includeAA },
+  );
+
+  const totalPixels = width * height;
+  const ratio = diffPixels / totalPixels;
+  const match = ratio <= mismatchRatio;
+
+  let diffPngPath: string | undefined;
+  if (!match) {
+    writeFileSync(diffPath, PNG.sync.write(diff));
+    diffPngPath = diffPath;
+  }
+
+  return { match, diffPixels, totalPixels, ratio, diffPngPath };
+}

--- a/tools/test/src/visual/harness.ts
+++ b/tools/test/src/visual/harness.ts
@@ -1,0 +1,171 @@
+/**
+ * Visual regression harness.
+ *
+ * Runs on the Node side of the Puppeteer browser test runner (not in
+ * the browser tab). Takes a full-page or selector-scoped screenshot,
+ * compares it against a baseline PNG, writes a diff PNG on mismatch,
+ * and returns the result. Set `POLLY_VISUAL_UPDATE=1` to overwrite the
+ * baseline instead of comparing — use only locally. CI should refuse
+ * that env var and fail on any diff.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import type { Page } from "puppeteer";
+import { compareImages, type VisualCompareOptions, type VisualCompareResult } from "./compare.ts";
+
+export type VisualMatchOptions = VisualCompareOptions & {
+  /** CSS selector to scope the screenshot. Defaults to the full page. */
+  selector?: string;
+  /** Elements matching these selectors are replaced with blanks before capture. */
+  maskSelectors?: string[];
+  /** Force prefers-color-scheme. Defaults to system. */
+  theme?: "light" | "dark";
+  /** Force prefers-reduced-motion. Defaults to system. */
+  motion?: "full" | "reduced";
+  /** Wait this long after setting emulation and before the shot. Default 100ms. */
+  settleMs?: number;
+};
+
+export type VisualMatchSuccess = {
+  name: string;
+  passed: true;
+  result: VisualCompareResult;
+};
+
+export type VisualMatchFailure = {
+  name: string;
+  passed: false;
+  reason: string;
+  result?: VisualCompareResult;
+  baselinePath: string;
+  actualPath: string;
+  diffPath?: string;
+};
+
+export type VisualMatchResult = VisualMatchSuccess | VisualMatchFailure;
+
+const UPDATE_ENV = "POLLY_VISUAL_UPDATE";
+const CI_ENV = "CI";
+
+export function isUpdateMode(): boolean {
+  return process.env[UPDATE_ENV] === "1";
+}
+
+export function isCi(): boolean {
+  return process.env[CI_ENV] === "true" || process.env[CI_ENV] === "1";
+}
+
+/** Refuses update mode in CI. Call at the top of a visual test runner. */
+export function assertSafeUpdateMode(): void {
+  if (isUpdateMode() && isCi()) {
+    throw new Error(
+      `${UPDATE_ENV}=1 is not allowed in CI. Regenerate baselines locally and commit them.`,
+    );
+  }
+}
+
+function maskInPage(page: Page, selectors: string[]): Promise<void> {
+  return page.evaluate((sels) => {
+    for (const sel of sels) {
+      const nodes = document.querySelectorAll<HTMLElement>(sel);
+      for (let i = 0; i < nodes.length; i += 1) {
+        const el = nodes[i];
+        if (el) el.style.visibility = "hidden";
+      }
+    }
+  }, selectors);
+}
+
+async function applyEmulation(page: Page, options: VisualMatchOptions): Promise<void> {
+  const features: Array<{ name: string; value: string }> = [];
+  if (options.theme) {
+    features.push({ name: "prefers-color-scheme", value: options.theme });
+  }
+  if (options.motion) {
+    features.push({
+      name: "prefers-reduced-motion",
+      value: options.motion === "reduced" ? "reduce" : "no-preference",
+    });
+  }
+  if (features.length > 0) {
+    await page.emulateMediaFeatures(features);
+  }
+}
+
+/**
+ * Take a screenshot, compare against the committed baseline, and return
+ * a structured result. When the baseline is missing, creates it (in
+ * update mode) or fails with a clear message (otherwise).
+ */
+export async function matchBaseline(
+  page: Page,
+  name: string,
+  baselinesDir: string,
+  diffsDir: string,
+  options: VisualMatchOptions = {},
+): Promise<VisualMatchResult> {
+  assertSafeUpdateMode();
+  await applyEmulation(page, options);
+  if (options.maskSelectors && options.maskSelectors.length > 0) {
+    await maskInPage(page, options.maskSelectors);
+  }
+  if (options.settleMs !== 0) {
+    await new Promise((r) => setTimeout(r, options.settleMs ?? 100));
+  }
+
+  const safeName = name.replace(/[^a-zA-Z0-9._-]+/g, "_");
+  const baselinePath = resolve(baselinesDir, `${safeName}.png`);
+  const actualPath = resolve(diffsDir, `${safeName}.actual.png`);
+  const diffPath = resolve(diffsDir, `${safeName}.diff.png`);
+
+  mkdirSync(dirname(baselinePath), { recursive: true });
+  mkdirSync(dirname(actualPath), { recursive: true });
+
+  const target = options.selector
+    ? await page.$(options.selector)
+    : null;
+  const screenshotBuffer: Buffer = target
+    ? Buffer.from(await target.screenshot({ type: "png" }))
+    : Buffer.from(await page.screenshot({ type: "png", fullPage: false }));
+
+  writeFileSync(actualPath, screenshotBuffer);
+
+  if (!existsSync(baselinePath) || isUpdateMode()) {
+    writeFileSync(baselinePath, screenshotBuffer);
+    return {
+      name,
+      passed: true,
+      result: {
+        match: true,
+        diffPixels: 0,
+        totalPixels: 0,
+        ratio: 0,
+      },
+    };
+  }
+
+  const result = compareImages(baselinePath, actualPath, diffPath, options);
+  if (result.match) {
+    return { name, passed: true, result };
+  }
+  return {
+    name,
+    passed: false,
+    reason: `Visual mismatch: ${result.diffPixels} pixel(s) differ (${(result.ratio * 100).toFixed(3)}%)`,
+    result,
+    baselinePath,
+    actualPath,
+    diffPath: result.diffPngPath,
+  };
+}
+
+export function resolveVisualPaths(projectRoot: string): {
+  baselinesDir: string;
+  diffsDir: string;
+} {
+  return {
+    baselinesDir: join(projectRoot, "tests/visual/__baselines__"),
+    diffsDir: join(projectRoot, "tests/visual/__diffs__"),
+  };
+}

--- a/tools/test/src/visual/harness.ts
+++ b/tools/test/src/visual/harness.ts
@@ -60,7 +60,7 @@ export function isCi(): boolean {
 export function assertSafeUpdateMode(): void {
   if (isUpdateMode() && isCi()) {
     throw new Error(
-      `${UPDATE_ENV}=1 is not allowed in CI. Regenerate baselines locally and commit them.`,
+      `${UPDATE_ENV}=1 is not allowed in CI. Regenerate baselines locally and commit them.`
     );
   }
 }
@@ -68,10 +68,8 @@ export function assertSafeUpdateMode(): void {
 function maskInPage(page: Page, selectors: string[]): Promise<void> {
   return page.evaluate((sels) => {
     for (const sel of sels) {
-      const nodes = document.querySelectorAll<HTMLElement>(sel);
-      for (let i = 0; i < nodes.length; i += 1) {
-        const el = nodes[i];
-        if (el) el.style.visibility = "hidden";
+      for (const el of Array.from(document.querySelectorAll<HTMLElement>(sel))) {
+        el.style.visibility = "hidden";
       }
     }
   }, selectors);
@@ -103,7 +101,7 @@ export async function matchBaseline(
   name: string,
   baselinesDir: string,
   diffsDir: string,
-  options: VisualMatchOptions = {},
+  options: VisualMatchOptions = {}
 ): Promise<VisualMatchResult> {
   assertSafeUpdateMode();
   await applyEmulation(page, options);
@@ -122,9 +120,7 @@ export async function matchBaseline(
   mkdirSync(dirname(baselinePath), { recursive: true });
   mkdirSync(dirname(actualPath), { recursive: true });
 
-  const target = options.selector
-    ? await page.$(options.selector)
-    : null;
+  const target = options.selector ? await page.$(options.selector) : null;
   const screenshotBuffer: Buffer = target
     ? Buffer.from(await target.screenshot({ type: "png" }))
     : Buffer.from(await page.screenshot({ type: "png", fullPage: false }));

--- a/tools/test/src/visual/index.ts
+++ b/tools/test/src/visual/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @fairfox/polly/test/visual — visual regression harness.
+ *
+ * Wraps the existing Puppeteer browser harness with screenshot capture
+ * and baseline diffing via pixelmatch. Consumer tests call
+ * `matchBaseline(page, name, baselinesDir, diffsDir)` on an already-
+ * rendered page; the result carries pass/fail plus the diff PNG path.
+ *
+ *   import { matchBaseline, resolveVisualPaths } from "@fairfox/polly/test/visual";
+ */
+
+export {
+  compareImages,
+  type VisualCompareOptions,
+  type VisualCompareResult,
+} from "./compare.ts";
+export {
+  assertSafeUpdateMode,
+  isCi,
+  isUpdateMode,
+  matchBaseline,
+  resolveVisualPaths,
+  type VisualMatchFailure,
+  type VisualMatchOptions,
+  type VisualMatchResult,
+  type VisualMatchSuccess,
+} from "./harness.ts";


### PR DESCRIPTION
Closes #51.

## Summary

Lingua and Fairfox independently arrived at the same UI architecture — a document-level event listener dispatches `data-action` events to a typed registry, which is the sole path by which state mutates. Lingua formalised it; Fairfox grew around it informally and paid the price in scattered callbacks. This PR lifts the pattern into Polly so that both projects, and every future one, can pick it up and focus on their domain instead of rebuilding the plumbing.

## What ships

- **`@fairfox/polly/actions`** — event-delegation runtime, typed `ActionRegistry`, `parseActionData`, overlay registry with Escape handling, a `FormStore` primitive with open/close and entity-guard semantics, a global error surface, a Preact `StoreProvider` / `useStores()`, and a testing harness of `createMockStores` / `createMockElement` / `createMockSubmitEvent` / `runAction`.
- **`@fairfox/polly/ui`** — `<Modal>`, `<ActionForm>`, `<ConfirmDialog>`, `<Toast>`, and `<OverlayRoot>`, plus `styles.css`, `theme.css`, and a bundled `components.css` under token-driven theming.
- **`recipes/actions-driven-app`** — the whole loop in one directory: event delegation wired in `main.tsx`, an action registry, a `FormStore` for the create/edit modal, three handler tests, two form tests, and a `$persistedState` slice so the state tier is visible end-to-end. The recipe is a copy-and-grow skeleton — `bun install`, `bun test tests`, `bunx tsc --noEmit` all run on a clean clone; bundler choice is left to the consumer, as the README states.
- **CSS conformance checks** — new `polly quality` checks covering CSS layout, quality, unused selectors, and variables, with unit coverage.
- **Visual regression harness** — new `@fairfox/polly/test/visual` and browser coverage for the UI primitives.
- **`docs/ACTIONS.md`, `docs/UI.md`, `docs/CSS.md`, `docs/TESTING.md`** — the pattern, the primitives, the conventions, and the handler test recipe in Polly's usual register.
- **0.25.1** — `CHANGELOG.md` entry, exports map updated, browser test runner shipped as `polly test:browser`, and a late fix for an elysia-barrel import hoist regression introduced during the cut.

## Out of this PR

- The Lingua migration — landing Polly's primitives in place of its hand-rolled event delegation and registry types — is the intended end-to-end proof per the acceptance criteria, and will ship as a follow-up PR in `AlexJeffcott/lingua` once this one lands.

## Verification

- `bun run typecheck` and `bun run lint` both clean (a single pre-existing stale-suppression warning unrelated to this branch).
- Unit, browser, and recipe tests all green.
- Full suite baseline-matches main — two SSL-certificate failures in `examples/team-task-manager` predate this branch.