### PR TITLE
Ship the markdown.js artefact that 0.26.0 declared but never emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.1] - 2026-04-17
+
+### Fixed
+
+Ship the compiled JavaScript for the `@fairfox/polly/ui/markdown`
+subpath. The 0.26.0 release declared the export in `package.json` and
+emitted `markdown.d.ts` through `tsc`, but `build-lib.ts` never listed
+`src/polly-ui/markdown.tsx` as a Bun.build entrypoint, so the
+corresponding `markdown.js` was absent from the published tarball.
+Consumers that imported `renderMarkdown` — notably The Struggle and
+Library in fairfox — compiled fine against the declaration file and
+then failed to bundle against the runtime module. The fix adds
+`src/polly-ui/markdown.tsx` to the library build's entrypoints list;
+the emitted `markdown.js` now rides alongside its declaration.
+
 ## [0.26.0] - 2026-04-17
 
 ### Added

--- a/build-lib.ts
+++ b/build-lib.ts
@@ -57,6 +57,10 @@ const libResult = await Bun.build({
     // UI primitives subpath
     "src/polly-ui/index.ts",
 
+    // Optional-peer UI helpers (separate subpath so marked + DOMPurify
+    // only ship in the bundles of consumers that import them).
+    "src/polly-ui/markdown.tsx",
+
     // Tool exports
     "tools/verify/src/config.ts",
     "tools/test/src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",


### PR DESCRIPTION
## Summary

The 0.26.0 release added `@fairfox/polly/ui/markdown` as a new subpath export. `package.json` registered the export, `tsc` wrote the declaration file through its `src/**/*` include, and every downstream typecheck passed. `build-lib.ts` never listed the source module as a `Bun.build` entrypoint though, and Bun.build emits only what its entrypoints list names, so the compiled JavaScript stayed absent from the published tarball. Consumers — notably The Struggle and Library in fairfox — type-checked cleanly against the declaration and then failed to bundle against the missing runtime module.

The fix adds `src/polly-ui/markdown.tsx` to the library-build entrypoints. `dist/src/polly-ui/markdown.js` now rides alongside its declaration, the subpath resolves at bundle time, and the version bumps to 0.26.1 to carry the fix to npm.