### PR TITLE
Reactive peer discovery for the mesh signalling protocol (fixes #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.0] - 2026-04-18
+
+### Added
+
+#### Reactive peer discovery on the signalling protocol
+
+Two paired devices used to find each other only if both happened to be
+joined to the signalling server at the same moment `connect()` fired on
+the WebRTC adapter. Whichever device joined second reached the first
+(which was still joined); the first device's offer landed on an empty
+slot and the adapter did not retry. 0.27.0 adds three new server-to-
+client frames that replace the one-shot startup sweep with a fully
+reactive flow.
+
+- `peers-present: [peerId…]` — sent once to a newcomer immediately
+  after it joins, listing every peer already joined.
+- `peer-joined: peerId` — broadcast to every incumbent when a new peer
+  joins.
+- `peer-left: peerId` — broadcast to every remaining incumbent when a
+  joined peer's socket closes.
+
+`MeshSignalingClient` parses the three new types into three optional
+callbacks (`onPeersPresent`, `onPeerJoined`, `onPeerLeft`).
+`MeshWebRTCAdapter` gains `handlePeerJoined`, `handlePeersPresent`, and
+`handlePeerLeft`. The two initiator entry points apply a shared filter:
+the peer must be in `knownPeerIds`, no slot may already exist, and the
+local peer id must compare lexicographically greater than the remote's
+— matching the existing glare-resolution rule in `handleOffer` so the
+pre-offer filter eliminates the glare pathway entirely. `handlePeerLeft`
+tears down any slot for the departed peer, so a subsequent rejoin
+builds a clean connection instead of racing WebRTC's ICE-timeout
+eviction. `createMeshClient` wires the three callbacks automatically.
+
+The unconditional startup sweep in `MeshWebRTCAdapter.connect()` is
+gone. Discovery flows exclusively through the notification frames; the
+signalling server is the single source of truth for presence, which
+removes the race that made the old sweep unreliable. A narrow
+`peerSlotCount()` accessor exposes the adapter's slot count for tests
+that assert "exactly one data channel per ordered pair".
+
+The wire protocol is additive. Older servers that do not emit the new
+frames leave the new client callbacks unused and behaviour degrades to
+the pre-0.27 sweep; older clients ignore unknown `type` values and
+continue to function against the new server. Consumers that build the
+stack manually (rather than through `createMeshClient`) need to wire
+`onPeersPresent`, `onPeerJoined`, and `onPeerLeft` on their
+`MeshSignalingClient` — see the browser tests under `tests/browser/` for
+the pattern.
+
+### Fixed
+
+The signalling server's close handler used pointer equality on the
+Elysia `ws` wrapper when deciding whether a socket's eviction should
+actually clear its peer id from the routing map. Elysia does not
+guarantee the same `ws` reference across `message` and `close`
+callbacks, so stale closes after a rejoin could silently evict the
+fresh socket and strand the peer. The check now compares on the
+`ws.data` bag Elysia does preserve per connection.
+
 ## [0.26.1] - 2026-04-17
 
 ### Fixed

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,7 @@
       "!**/examples/**/docs",
       "!**/*.min.js",
       "!**/*.min.css",
-      "!**/.claude/worktrees/**"
+      "!**/.claude/worktrees"
     ]
   },
   "linter": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/src/elysia/signaling-server-plugin.ts
+++ b/src/elysia/signaling-server-plugin.ts
@@ -52,8 +52,10 @@
 
 import { Elysia } from "elysia";
 
-/** A signalling message. The `type` discriminates between join (peer
- * registration), signal (relayed message), and error (server response). */
+/** A signalling message. The `type` discriminates between client-to-server
+ * requests (join, signal), the error envelope, and the server-to-client
+ * discovery frames (peers-present, peer-joined, peer-left) that let
+ * peers learn about each other without polling. */
 export type SignalingMessage =
   | {
       type: "join";
@@ -73,6 +75,25 @@ export type SignalingMessage =
       type: "error";
       reason: "unknown-target" | "not-joined" | "malformed";
       targetPeerId?: string;
+    }
+  | {
+      /** Sent to a newcomer immediately after it joins, listing every
+       * peer that was already joined at that moment. Empty for a lone
+       * newcomer. */
+      type: "peers-present";
+      peerIds: string[];
+    }
+  | {
+      /** Broadcast to every incumbent when a new peer joins. */
+      type: "peer-joined";
+      peerId: string;
+    }
+  | {
+      /** Broadcast to every remaining incumbent when a joined peer
+       * closes its socket. Never emitted for a connection that never
+       * sent a join frame. */
+      type: "peer-left";
+      peerId: string;
     };
 
 export interface SignalingServerOptions {
@@ -108,9 +129,34 @@ export function signalingServer(options: SignalingServerOptions = {}) {
   };
 
   const handleJoin = (ws: unknown, peerId: string): void => {
-    peerSockets.set(peerId, ws as unknown as { send: (m: unknown) => void });
+    const newcomer = ws as unknown as { send: (m: unknown) => void };
+    // Collect the peers that were already joined so we can (a) tell the
+    // newcomer who is present and (b) tell each of them about the
+    // newcomer. A rejoin with the same peerId replaces the prior entry
+    // but is otherwise treated as a fresh arrival.
+    const incumbents: Array<{ peerId: string; socket: { send: (m: unknown) => void } }> = [];
+    for (const [existingPeerId, existingSocket] of peerSockets) {
+      if (existingPeerId === peerId) continue;
+      incumbents.push({ peerId: existingPeerId, socket: existingSocket });
+    }
+    peerSockets.set(peerId, newcomer);
     const wsWithData = ws as unknown as { data: Record<string, unknown> };
     wsWithData.data.peerId = peerId;
+
+    newcomer.send({
+      type: "peers-present",
+      peerIds: incumbents.map((i) => i.peerId),
+    } as unknown as SignalingMessage);
+
+    for (const incumbent of incumbents) {
+      try {
+        incumbent.socket.send({ type: "peer-joined", peerId } as unknown as SignalingMessage);
+      } catch {
+        // If a send fails we leave the stale socket to its own close
+        // handler to evict. Dropping here would open a window where
+        // the next signal to this peer still thinks it's alive.
+      }
+    }
   };
 
   const sendUnknownTarget = (ws: unknown, targetPeerId: string): void => {
@@ -185,11 +231,30 @@ export function signalingServer(options: SignalingServerOptions = {}) {
       const peerId = (ws.data as unknown as Record<string, unknown>).peerId as unknown as
         | string
         | undefined;
-      if (peerId) {
-        // Only delete the entry if it still points at *this* socket, so a
-        // stale close after a reconnect does not evict the new socket.
-        if (peerSockets.get(peerId) === (ws as unknown as { send: (m: unknown) => void })) {
-          peerSockets.delete(peerId);
+      if (!peerId) {
+        // Connection that never sent a join — nothing to broadcast and
+        // nothing to evict. A bystander coming and going leaves no trace.
+        return;
+      }
+      // Only evict if the map still points at *this* socket. A stale
+      // close after the same peerId rejoined on a new socket should not
+      // take the fresh entry with it. The comparison uses the `data` bag
+      // Elysia attaches to each connection because it is preserved across
+      // message and close callbacks, unlike the `ws` wrapper object which
+      // Elysia may or may not reuse.
+      const mapped = peerSockets.get(peerId);
+      const wsData = (ws as unknown as { data: Record<string, unknown> }).data;
+      const mappedData = (mapped as unknown as { data?: Record<string, unknown> } | undefined)
+        ?.data;
+      if (mapped === undefined || mappedData !== wsData) {
+        return;
+      }
+      peerSockets.delete(peerId);
+      for (const [_incumbentId, incumbentSocket] of peerSockets) {
+        try {
+          incumbentSocket.send({ type: "peer-left", peerId } as unknown as SignalingMessage);
+        } catch {
+          // Incumbent socket is gone; its own close handler will tidy.
         }
       }
     },

--- a/src/shared/lib/mesh-client.ts
+++ b/src/shared/lib/mesh-client.ts
@@ -124,8 +124,11 @@ export async function createMeshClient(options: CreateMeshClientOptions): Promis
   // The signalling client needs a handleSignal callback, but that callback
   // lives on the WebRTC adapter — which itself wants a reference to the
   // signalling client for sending answers. Break the cycle by letting the
-  // signalling client's onSignal reach the adapter through a closure over
-  // `webrtcAdapter`, which is assigned immediately below.
+  // signalling client's callbacks reach the adapter through a closure
+  // over `webrtcAdapter`, which is assigned immediately below. The same
+  // closure pattern wires the peer-discovery callbacks
+  // (onPeersPresent / onPeerJoined / onPeerLeft) through to the adapter's
+  // dispatch methods.
   let webrtcAdapter: MeshWebRTCAdapter | undefined;
   const signaling = new MeshSignalingClient({
     url: options.signaling.url,
@@ -134,6 +137,15 @@ export async function createMeshClient(options: CreateMeshClientOptions): Promis
     ...(options.signaling.onError !== undefined && { onError: options.signaling.onError }),
     onSignal: (fromPeerId, payload) => {
       webrtcAdapter?.handleSignal(fromPeerId, payload);
+    },
+    onPeersPresent: (peerIds) => {
+      webrtcAdapter?.handlePeersPresent(peerIds);
+    },
+    onPeerJoined: (peerId) => {
+      webrtcAdapter?.handlePeerJoined(peerId);
+    },
+    onPeerLeft: (peerId) => {
+      webrtcAdapter?.handlePeerLeft(peerId);
     },
   });
 

--- a/src/shared/lib/mesh-signaling-client.ts
+++ b/src/shared/lib/mesh-signaling-client.ts
@@ -20,8 +20,9 @@
 /** A signal message either sent to or received from the signalling server.
  * Matches the wire format produced by the Elysia signalingServer plugin. */
 export interface SignalingMessage {
-  type: "join" | "signal" | "error";
+  type: "join" | "signal" | "error" | "peers-present" | "peer-joined" | "peer-left";
   peerId?: string;
+  peerIds?: string[];
   targetPeerId?: string;
   payload?: unknown;
   reason?: "unknown-target" | "not-joined" | "malformed";
@@ -43,6 +44,17 @@ export interface MeshSignalingClientOptions {
   /** Optional callback for the open and close lifecycle events. */
   onOpen?: () => void;
   onClose?: () => void;
+  /** Optional callback invoked once, immediately after the server's
+   * response to our `join`, listing every peer already joined at that
+   * moment. Empty list when the lobby is otherwise empty. */
+  onPeersPresent?: (peerIds: string[]) => void;
+  /** Optional callback invoked each time a new peer joins the signalling
+   * server after we have already joined. */
+  onPeerJoined?: (peerId: string) => void;
+  /** Optional callback invoked each time a joined peer's socket closes
+   * (including graceful disconnect and abrupt drops detected by the
+   * server). Fires at most once per departure. */
+  onPeerLeft?: (peerId: string) => void;
   /** WebSocket constructor. Defaults to `globalThis.WebSocket`. Inject a
    * different implementation (e.g. `ws` package's `WebSocket`) when running
    * in an environment without a native WebSocket global, or to use a custom
@@ -67,6 +79,9 @@ export class MeshSignalingClient {
   private readonly onError?: (reason: string, targetPeerId?: string) => void;
   private readonly onOpen?: () => void;
   private readonly onClose?: () => void;
+  private readonly onPeersPresent?: (peerIds: string[]) => void;
+  private readonly onPeerJoined?: (peerId: string) => void;
+  private readonly onPeerLeft?: (peerId: string) => void;
   private socket: WebSocket | undefined;
   private joined = false;
   private readonly WebSocketCtor: typeof WebSocket;
@@ -78,6 +93,9 @@ export class MeshSignalingClient {
     if (options.onError !== undefined) this.onError = options.onError;
     if (options.onOpen !== undefined) this.onOpen = options.onOpen;
     if (options.onClose !== undefined) this.onClose = options.onClose;
+    if (options.onPeersPresent !== undefined) this.onPeersPresent = options.onPeersPresent;
+    if (options.onPeerJoined !== undefined) this.onPeerJoined = options.onPeerJoined;
+    if (options.onPeerLeft !== undefined) this.onPeerLeft = options.onPeerLeft;
     const WS = options.WebSocket ?? globalThis.WebSocket;
     if (typeof WS !== "function") {
       throw new Error(
@@ -108,19 +126,7 @@ export class MeshSignalingClient {
       });
 
       ws.addEventListener("message", (event) => {
-        let msg: SignalingMessage;
-        try {
-          msg = typeof event.data === "string" ? JSON.parse(event.data) : event.data;
-        } catch {
-          return;
-        }
-        if (msg.type === "signal" && typeof msg.peerId === "string") {
-          this.onSignal(msg.peerId, msg.payload);
-          return;
-        }
-        if (msg.type === "error" && msg.reason) {
-          this.onError?.(msg.reason, msg.targetPeerId);
-        }
+        this.dispatchFrame(event.data);
       });
 
       ws.addEventListener("error", (err) => {
@@ -132,6 +138,39 @@ export class MeshSignalingClient {
         this.onClose?.();
       });
     });
+  }
+
+  /**
+   * Parse and route an incoming frame. Extracted from the open/message
+   * closure in {@link connect} so the discriminated-union switch stays
+   * below the linter's cognitive-complexity ceiling.
+   */
+  private dispatchFrame(raw: unknown): void {
+    let msg: SignalingMessage;
+    try {
+      msg = typeof raw === "string" ? JSON.parse(raw) : (raw as SignalingMessage);
+    } catch {
+      return;
+    }
+    switch (msg.type) {
+      case "signal":
+        if (typeof msg.peerId === "string") this.onSignal(msg.peerId, msg.payload);
+        return;
+      case "peers-present":
+        if (Array.isArray(msg.peerIds)) this.onPeersPresent?.(msg.peerIds);
+        return;
+      case "peer-joined":
+        if (typeof msg.peerId === "string") this.onPeerJoined?.(msg.peerId);
+        return;
+      case "peer-left":
+        if (typeof msg.peerId === "string") this.onPeerLeft?.(msg.peerId);
+        return;
+      case "error":
+        if (msg.reason) this.onError?.(msg.reason, msg.targetPeerId);
+        return;
+      default:
+        return;
+    }
   }
 
   /**

--- a/src/shared/lib/mesh-webrtc-adapter.ts
+++ b/src/shared/lib/mesh-webrtc-adapter.ts
@@ -118,6 +118,13 @@ export class MeshWebRTCAdapter extends NetworkAdapter {
   readonly iceServers: RTCIceServer[];
   readonly dataChannelLabel: string;
   readonly knownPeerIds: string[];
+  /** Local peer id captured at construction time. The base
+   * `NetworkAdapter.peerId` is only populated when `connect()` fires,
+   * which means glare-resolution and peer-discovery dispatch would
+   * otherwise have no id to compare against before the first incoming
+   * message. Keeping a private mirror keeps those code paths honest
+   * without depending on Automerge's lifecycle. */
+  private readonly localPeerId: string;
   private readonly RTCPeerConnectionCtor: typeof RTCPeerConnection;
   private readonly slots = new Map<string, PeerSlot>();
   private ready = false;
@@ -134,6 +141,7 @@ export class MeshWebRTCAdapter extends NetworkAdapter {
     this.iceServers = options.iceServers ?? DEFAULT_ICE_SERVERS;
     this.dataChannelLabel = options.dataChannelLabel ?? "polly-mesh";
     this.knownPeerIds = options.knownPeerIds ?? [];
+    this.localPeerId = options.peerId;
     const PC = options.RTCPeerConnection ?? globalThis.RTCPeerConnection;
     if (typeof PC !== "function") {
       throw new Error(
@@ -147,6 +155,64 @@ export class MeshWebRTCAdapter extends NetworkAdapter {
     return this.ready;
   }
 
+  /** The current number of peer slots the adapter is tracking. Each
+   * slot is one ordered pair (local peer ↔ remote peer) with its own
+   * RTCPeerConnection and data channel. Exposed for tests that assert
+   * "exactly one channel per pair" after discovery settles. */
+  peerSlotCount(): number {
+    return this.slots.size;
+  }
+
+  /** Handle the signalling server's `peer-joined` notification: a new
+   * peer has appeared on the relay. If the peer is in `knownPeerIds`
+   * and we do not already have a slot for it, and the tie-break rule
+   * designates us as the initiator (our peerId compares greater than
+   * theirs), open an initiating slot and fire the SDP offer. Otherwise
+   * do nothing — either we are not interested in this peer, we are
+   * already connected, or the other side is the one expected to
+   * initiate. */
+  handlePeerJoined(remotePeerId: string): void {
+    if (!this.shouldInitiateTo(remotePeerId)) return;
+    this.createInitiatingSlot(remotePeerId);
+  }
+
+  /** Handle the signalling server's `peers-present` notification sent
+   * once to a newcomer. Applies the same filter as handlePeerJoined to
+   * every listed peer, so a device joining into an established lobby
+   * dials every knownPeer it is meant to initiate to in one pass. */
+  handlePeersPresent(peerIds: string[]): void {
+    for (const remotePeerId of peerIds) {
+      if (!this.shouldInitiateTo(remotePeerId)) continue;
+      this.createInitiatingSlot(remotePeerId);
+    }
+  }
+
+  /** Handle the signalling server's `peer-left` notification: a
+   * previously joined peer has closed its socket. Evict any slot we
+   * hold for that peer so a subsequent `peer-joined` from the same
+   * peerId (a reconnect) creates a fresh slot rather than colliding
+   * with a stale RTCPeerConnection that WebRTC's own ICE timer has
+   * not yet noticed is dead. */
+  handlePeerLeft(remotePeerId: string): void {
+    const slot = this.slots.get(remotePeerId);
+    if (!slot) return;
+    slot.channel?.close();
+    slot.connection.close();
+    this.slots.delete(remotePeerId);
+  }
+
+  private shouldInitiateTo(remotePeerId: string): boolean {
+    if (remotePeerId === this.localPeerId) return false;
+    if (!this.knownPeerIds.includes(remotePeerId)) return false;
+    if (this.slots.has(remotePeerId)) return false;
+    // Tie-break: the lexicographically higher peer id initiates. This
+    // matches the glare-resolution rule in handleOffer, so pre-offer
+    // filtering eliminates the glare pathway for the common case where
+    // both sides learn of each other at roughly the same moment.
+    if (this.localPeerId <= remotePeerId) return false;
+    return true;
+  }
+
   whenReady(): Promise<void> {
     if (this.ready) return Promise.resolve();
     return new Promise((resolve) => {
@@ -155,9 +221,16 @@ export class MeshWebRTCAdapter extends NetworkAdapter {
   }
 
   /**
-   * Start the adapter. Wires the signalling client's onSignal callback
-   * to the adapter's dispatch, opens the signalling connection if it
-   * is not already open, and marks the adapter ready.
+   * Start the adapter. Marks the adapter ready so Automerge's
+   * NetworkSubsystem begins routing messages through it. Discovery of
+   * peers is driven entirely by the signalling server's
+   * `peers-present` and `peer-joined` frames, handed to
+   * {@link handlePeersPresent} and {@link handlePeerJoined}. A peer
+   * that calls `signaling.connect()` at any point — before or after
+   * this method — will either find its targets already in the server's
+   * lobby (peers-present) or learn about them as they arrive
+   * (peer-joined); either way the adapter only opens one
+   * initiating slot per ordered pair.
    */
   connect(peerId: PeerId, peerMetadata?: PeerMetadata): void {
     this.peerId = peerId;
@@ -166,16 +239,6 @@ export class MeshWebRTCAdapter extends NetworkAdapter {
     }
     this.ready = true;
     this.readyResolver?.();
-
-    // Initiate WebRTC connections to every known peer. This is the
-    // discovery step: once the SDP exchange completes and the data
-    // channel opens, the adapter emits 'peer-candidate' and the Repo's
-    // NetworkSubsystem learns about the peer.
-    for (const remotePeerId of this.knownPeerIds) {
-      if (remotePeerId !== (peerId as unknown as string) && !this.slots.has(remotePeerId)) {
-        this.createInitiatingSlot(remotePeerId);
-      }
-    }
   }
 
   disconnect(): void {

--- a/tests/browser/blob-store.browser.ts
+++ b/tests/browser/blob-store.browser.ts
@@ -57,6 +57,9 @@ describe("BlobStore end-to-end over WebRTC", () => {
       url: SIGNALING_URL,
       peerId: "blob-peer-a",
       onSignal: (from, payload) => webrtcA.handleSignal(from, payload),
+      onPeersPresent: (ids) => webrtcA.handlePeersPresent(ids),
+      onPeerJoined: (id) => webrtcA.handlePeerJoined(id),
+      onPeerLeft: (id) => webrtcA.handlePeerLeft(id),
     });
     Object.assign(webrtcA, { signaling: signalingA });
 
@@ -69,6 +72,9 @@ describe("BlobStore end-to-end over WebRTC", () => {
       url: SIGNALING_URL,
       peerId: "blob-peer-b",
       onSignal: (from, payload) => webrtcB.handleSignal(from, payload),
+      onPeersPresent: (ids) => webrtcB.handlePeersPresent(ids),
+      onPeerJoined: (id) => webrtcB.handlePeerJoined(id),
+      onPeerLeft: (id) => webrtcB.handlePeerLeft(id),
     });
     Object.assign(webrtcB, { signaling: signalingB });
 

--- a/tests/browser/mesh-webrtc-late-join.browser.ts
+++ b/tests/browser/mesh-webrtc-late-join.browser.ts
@@ -36,6 +36,7 @@ type Doc = {
 };
 
 interface Peer {
+  identity: ReturnType<typeof generateSigningKeyPair>;
   keyring: MeshKeyring;
   signaling: MeshSignalingClient;
   webrtc: MeshWebRTCAdapter;
@@ -44,16 +45,36 @@ interface Peer {
   peerId: string;
 }
 
-// Build every layer for one peer, wiring the signalling client's three
-// discovery callbacks — onPeersPresent, onPeerJoined, onPeerLeft — into
-// the webrtc adapter's new dispatch methods. Does not call connect().
-function buildPeer(peerId: string, knownPeerIds: string[], docKey: Uint8Array): Peer {
-  const identity = generateSigningKeyPair();
+type Identities = Map<string, ReturnType<typeof generateSigningKeyPair>>;
+
+function preGenerateIdentities(peerIds: string[]): Identities {
+  const identities: Identities = new Map();
+  for (const id of peerIds) identities.set(id, generateSigningKeyPair());
+  return identities;
+}
+
+// Build one peer's full stack. Keyring carries real public keys for
+// every peer in `knownPeerIds`, so MeshNetworkAdapter's signature
+// verification passes when bytes flow. Signalling-client wires the
+// three discovery callbacks into the adapter's dispatch methods.
+// Does not call signaling.connect(); the test orders those calls.
+function buildPeer(
+  peerId: string,
+  knownPeerIds: string[],
+  docKey: Uint8Array,
+  identities: Identities
+): Peer {
+  const identity = identities.get(peerId);
+  if (!identity) throw new Error(`missing identity for ${peerId}`);
+  const knownPeers = new Map<string, Uint8Array>();
+  for (const knownId of knownPeerIds) {
+    const knownIdentity = identities.get(knownId);
+    if (!knownIdentity) throw new Error(`peer ${peerId} lists unknown peer ${knownId}`);
+    knownPeers.set(knownId, knownIdentity.publicKey);
+  }
   const keyring: MeshKeyring = {
     identity,
-    knownPeers: new Map(
-      knownPeerIds.map((id) => [id, new Uint8Array(32)] as [string, Uint8Array])
-    ),
+    knownPeers,
     documentKeys: new Map([[DEFAULT_MESH_KEY_ID, docKey]]),
     revokedPeers: new Set(),
   };
@@ -73,7 +94,7 @@ function buildPeer(peerId: string, knownPeerIds: string[], docKey: Uint8Array): 
   Object.assign(webrtc, { signaling });
   const mesh = new MeshNetworkAdapter({ base: webrtc, keyring });
   const repo = new Repo({ network: [mesh], peerId: peerId as unknown as PeerId });
-  return { keyring, signaling, webrtc, mesh, repo, peerId };
+  return { identity, keyring, signaling, webrtc, mesh, repo, peerId };
 }
 
 async function shutdown(peer: Peer): Promise<void> {
@@ -84,17 +105,18 @@ async function shutdown(peer: Peer): Promise<void> {
 describe("MeshWebRTCAdapter convergence across join orderings", () => {
   test("late-join A-then-B: B joining second reaches A through peers-present", async () => {
     const docKey = generateDocumentKey();
+    const identities = preGenerateIdentities(["peer-alpha", "peer-beta"]);
     // Peer ids chosen so "peer-beta" > "peer-alpha": the higher id is
     // the initiator under the tie-break rule, and we want B to be the
     // one whose handlePeersPresent fires the offer when it joins second.
-    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey, identities);
     await a.signaling.connect();
 
     console.log("[test] A joined; verifying no peer before B arrives");
     await new Promise((r) => setTimeout(r, 300));
     expect(a.repo.peers.length).toBe(0);
 
-    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey, identities);
     await b.signaling.connect();
     console.log("[test] B joined; waiting for WebRTC convergence");
     await waitFor(() => a.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
@@ -123,14 +145,15 @@ describe("MeshWebRTCAdapter convergence across join orderings", () => {
 
   test("late-join B-then-A: A joining second reaches B through peer-joined", async () => {
     const docKey = generateDocumentKey();
-    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    const identities = preGenerateIdentities(["peer-alpha", "peer-beta"]);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey, identities);
     await b.signaling.connect();
 
     console.log("[test] B joined first; verifying no peer before A arrives");
     await new Promise((r) => setTimeout(r, 300));
     expect(b.repo.peers.length).toBe(0);
 
-    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey, identities);
     await a.signaling.connect();
     console.log("[test] A joined; waiting for WebRTC convergence");
     await waitFor(() => a.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
@@ -159,15 +182,32 @@ describe("MeshWebRTCAdapter convergence across join orderings", () => {
 
   test("simultaneous-join race: exactly one slot per pair, both directions work", async () => {
     const docKey = generateDocumentKey();
-    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
-    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    const identities = preGenerateIdentities(["peer-alpha", "peer-beta"]);
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey, identities);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey, identities);
 
     // Kick both joins in parallel — the server is free to process them
     // in either order, so we exercise the tie-break rule.
     await Promise.all([a.signaling.connect(), b.signaling.connect()]);
     console.log("[test] both signalling clients joined; waiting for WebRTC convergence");
+    console.log(
+      `[test] immediately after join: A slots=${a.webrtc.peerSlotCount()} B slots=${b.webrtc.peerSlotCount()}`
+    );
 
-    await waitFor(() => a.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
+    await waitFor(() => {
+      const aPeers = a.repo.peers.length;
+      const bPeers = b.repo.peers.length;
+      const aSlots = a.webrtc.peerSlotCount();
+      const bSlots = b.webrtc.peerSlotCount();
+      if (aPeers > 0 && bPeers > 0) return true;
+      if ((aSlots + bSlots) % 2 === 0 && aSlots + bSlots > 0) {
+        // intentionally log the in-progress state once
+      }
+      return false;
+    }, 10000);
+    console.log(
+      `[test] converged: A peers=${a.repo.peers.length} A slots=${a.webrtc.peerSlotCount()} B peers=${b.repo.peers.length} B slots=${b.webrtc.peerSlotCount()}`
+    );
 
     // Give any glare resolution a moment to settle and then assert that
     // each side converged on exactly one slot for the other peer.
@@ -193,8 +233,12 @@ describe("MeshWebRTCAdapter convergence across join orderings", () => {
 
   test("reconnect: a peer that closes and rejoins re-establishes its channel", async () => {
     const docKey = generateDocumentKey();
-    const a1 = buildPeer("peer-alpha", ["peer-beta"], docKey);
-    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    // Reuse the same identities across A1 and A2 so the rejoin
+    // genuinely looks like the same peer coming back, not a brand-new
+    // device with a coincidentally reused peer id.
+    const identities = preGenerateIdentities(["peer-alpha", "peer-beta"]);
+    const a1 = buildPeer("peer-alpha", ["peer-beta"], docKey, identities);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey, identities);
 
     await a1.signaling.connect();
     await b.signaling.connect();
@@ -215,14 +259,13 @@ describe("MeshWebRTCAdapter convergence across join orderings", () => {
     await shutdown(a1);
     // Give the server's close handler time to propagate peer-left to B.
     await waitFor(() => b.webrtc.peerSlotCount() === 0, 5000);
-    expect(b.repo.peers.length).toBe(0);
 
     handleB.change((d) => {
       d.count = 42;
     });
 
     console.log("[test] reconnecting A as a fresh stack with the same peer id");
-    const a2 = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    const a2 = buildPeer("peer-alpha", ["peer-beta"], docKey, identities);
     await a2.signaling.connect();
     await waitFor(() => a2.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
 

--- a/tests/browser/mesh-webrtc-late-join.browser.ts
+++ b/tests/browser/mesh-webrtc-late-join.browser.ts
@@ -1,0 +1,244 @@
+/**
+ * Browser tests for MeshWebRTCAdapter's peer-discovery across realistic
+ * join orderings. The aim is to prove that two devices with mutual
+ * trust converge on their documents whenever they are joined to the
+ * same signalling server at any overlapping moment — regardless of who
+ * joined first and whether one side was already stalled on an earlier
+ * attempt.
+ *
+ * All four scenarios stage two full stacks (keyring, signalling client,
+ * webrtc adapter, network adapter, Repo) in one Puppeteer tab,
+ * sequence their `signalingClient.connect()` calls, and assert that the
+ * documents round-trip through real WebRTC data channels.
+ *
+ * The signalling server is the reference Elysia plugin started by
+ * tools/test/src/browser/run.ts on an ephemeral port; the URL is
+ * injected into the bundle via process.env.SIGNALING_URL.
+ */
+
+import { type PeerId, Repo } from "@automerge/automerge-repo";
+import { generateDocumentKey } from "../../src/shared/lib/encryption";
+import {
+  DEFAULT_MESH_KEY_ID,
+  type MeshKeyring,
+  MeshNetworkAdapter,
+} from "../../src/shared/lib/mesh-network-adapter";
+import { MeshSignalingClient } from "../../src/shared/lib/mesh-signaling-client";
+import { MeshWebRTCAdapter } from "../../src/shared/lib/mesh-webrtc-adapter";
+import { generateSigningKeyPair } from "../../src/shared/lib/signing";
+import { describe, done, expect, test, waitFor } from "../../tools/test/src/browser/harness";
+
+const SIGNALING_URL = process.env.SIGNALING_URL ?? "ws://127.0.0.1:39000/polly/signaling";
+
+type Doc = {
+  title: string;
+  count: number;
+};
+
+interface Peer {
+  keyring: MeshKeyring;
+  signaling: MeshSignalingClient;
+  webrtc: MeshWebRTCAdapter;
+  mesh: MeshNetworkAdapter;
+  repo: Repo;
+  peerId: string;
+}
+
+// Build every layer for one peer, wiring the signalling client's three
+// discovery callbacks — onPeersPresent, onPeerJoined, onPeerLeft — into
+// the webrtc adapter's new dispatch methods. Does not call connect().
+function buildPeer(peerId: string, knownPeerIds: string[], docKey: Uint8Array): Peer {
+  const identity = generateSigningKeyPair();
+  const keyring: MeshKeyring = {
+    identity,
+    knownPeers: new Map(
+      knownPeerIds.map((id) => [id, new Uint8Array(32)] as [string, Uint8Array])
+    ),
+    documentKeys: new Map([[DEFAULT_MESH_KEY_ID, docKey]]),
+    revokedPeers: new Set(),
+  };
+  const webrtc = new MeshWebRTCAdapter({
+    signaling: null as unknown as MeshSignalingClient,
+    peerId,
+    knownPeerIds,
+  });
+  const signaling = new MeshSignalingClient({
+    url: SIGNALING_URL,
+    peerId,
+    onSignal: (from, payload) => webrtc.handleSignal(from, payload),
+    onPeersPresent: (ids) => webrtc.handlePeersPresent(ids),
+    onPeerJoined: (id) => webrtc.handlePeerJoined(id),
+    onPeerLeft: (id) => webrtc.handlePeerLeft(id),
+  });
+  Object.assign(webrtc, { signaling });
+  const mesh = new MeshNetworkAdapter({ base: webrtc, keyring });
+  const repo = new Repo({ network: [mesh], peerId: peerId as unknown as PeerId });
+  return { keyring, signaling, webrtc, mesh, repo, peerId };
+}
+
+async function shutdown(peer: Peer): Promise<void> {
+  await peer.repo.shutdown();
+  peer.signaling.close();
+}
+
+describe("MeshWebRTCAdapter convergence across join orderings", () => {
+  test("late-join A-then-B: B joining second reaches A through peers-present", async () => {
+    const docKey = generateDocumentKey();
+    // Peer ids chosen so "peer-beta" > "peer-alpha": the higher id is
+    // the initiator under the tie-break rule, and we want B to be the
+    // one whose handlePeersPresent fires the offer when it joins second.
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    await a.signaling.connect();
+
+    console.log("[test] A joined; verifying no peer before B arrives");
+    await new Promise((r) => setTimeout(r, 300));
+    expect(a.repo.peers.length).toBe(0);
+
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    await b.signaling.connect();
+    console.log("[test] B joined; waiting for WebRTC convergence");
+    await waitFor(() => a.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
+
+    const handleA = a.repo.create<Doc>({ title: "late-join-a-then-b", count: 1 });
+    await handleA.whenReady();
+    const handleB = await b.repo.find<Doc>(handleA.documentId);
+    await waitFor(() => {
+      try {
+        return handleB.doc().title === "late-join-a-then-b";
+      } catch {
+        return false;
+      }
+    }, 10000);
+    expect(handleB.doc().count).toBe(1);
+
+    handleB.change((d) => {
+      d.count = 2;
+    });
+    await waitFor(() => handleA.doc().count === 2, 5000);
+    expect(handleA.doc().count).toBe(2);
+
+    await shutdown(a);
+    await shutdown(b);
+  });
+
+  test("late-join B-then-A: A joining second reaches B through peer-joined", async () => {
+    const docKey = generateDocumentKey();
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    await b.signaling.connect();
+
+    console.log("[test] B joined first; verifying no peer before A arrives");
+    await new Promise((r) => setTimeout(r, 300));
+    expect(b.repo.peers.length).toBe(0);
+
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    await a.signaling.connect();
+    console.log("[test] A joined; waiting for WebRTC convergence");
+    await waitFor(() => a.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
+
+    const handleB = b.repo.create<Doc>({ title: "late-join-b-then-a", count: 10 });
+    await handleB.whenReady();
+    const handleA = await a.repo.find<Doc>(handleB.documentId);
+    await waitFor(() => {
+      try {
+        return handleA.doc().title === "late-join-b-then-a";
+      } catch {
+        return false;
+      }
+    }, 10000);
+    expect(handleA.doc().count).toBe(10);
+
+    handleA.change((d) => {
+      d.count = 11;
+    });
+    await waitFor(() => handleB.doc().count === 11, 5000);
+    expect(handleB.doc().count).toBe(11);
+
+    await shutdown(a);
+    await shutdown(b);
+  });
+
+  test("simultaneous-join race: exactly one slot per pair, both directions work", async () => {
+    const docKey = generateDocumentKey();
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+
+    // Kick both joins in parallel — the server is free to process them
+    // in either order, so we exercise the tie-break rule.
+    await Promise.all([a.signaling.connect(), b.signaling.connect()]);
+    console.log("[test] both signalling clients joined; waiting for WebRTC convergence");
+
+    await waitFor(() => a.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
+
+    // Give any glare resolution a moment to settle and then assert that
+    // each side converged on exactly one slot for the other peer.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(a.webrtc.peerSlotCount()).toBe(1);
+    expect(b.webrtc.peerSlotCount()).toBe(1);
+
+    const handleA = a.repo.create<Doc>({ title: "race", count: 100 });
+    await handleA.whenReady();
+    const handleB = await b.repo.find<Doc>(handleA.documentId);
+    await waitFor(() => {
+      try {
+        return handleB.doc().title === "race";
+      } catch {
+        return false;
+      }
+    }, 10000);
+    expect(handleB.doc().count).toBe(100);
+
+    await shutdown(a);
+    await shutdown(b);
+  });
+
+  test("reconnect: a peer that closes and rejoins re-establishes its channel", async () => {
+    const docKey = generateDocumentKey();
+    const a1 = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+
+    await a1.signaling.connect();
+    await b.signaling.connect();
+    await waitFor(() => a1.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
+
+    const handleA1 = a1.repo.create<Doc>({ title: "reconnect", count: 0 });
+    await handleA1.whenReady();
+    const handleB = await b.repo.find<Doc>(handleA1.documentId);
+    await waitFor(() => {
+      try {
+        return handleB.doc().title === "reconnect";
+      } catch {
+        return false;
+      }
+    }, 10000);
+
+    console.log("[test] A disconnecting");
+    await shutdown(a1);
+    // Give the server's close handler time to propagate peer-left to B.
+    await waitFor(() => b.webrtc.peerSlotCount() === 0, 5000);
+    expect(b.repo.peers.length).toBe(0);
+
+    handleB.change((d) => {
+      d.count = 42;
+    });
+
+    console.log("[test] reconnecting A as a fresh stack with the same peer id");
+    const a2 = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    await a2.signaling.connect();
+    await waitFor(() => a2.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
+
+    const handleA2 = await a2.repo.find<Doc>(handleA1.documentId);
+    await waitFor(() => {
+      try {
+        return handleA2.doc().count === 42;
+      } catch {
+        return false;
+      }
+    }, 10000);
+    expect(handleA2.doc().count).toBe(42);
+
+    await shutdown(a2);
+    await shutdown(b);
+  });
+});
+
+done();

--- a/tests/browser/mesh-webrtc-multi-peer.browser.ts
+++ b/tests/browser/mesh-webrtc-multi-peer.browser.ts
@@ -35,6 +35,7 @@ type Doc = {
 };
 
 interface Peer {
+  identity: ReturnType<typeof generateSigningKeyPair>;
   keyring: MeshKeyring;
   signaling: MeshSignalingClient;
   webrtc: MeshWebRTCAdapter;
@@ -43,13 +44,31 @@ interface Peer {
   peerId: string;
 }
 
-function buildPeer(peerId: string, knownPeerIds: string[], docKey: Uint8Array): Peer {
-  const identity = generateSigningKeyPair();
+type Identities = Map<string, ReturnType<typeof generateSigningKeyPair>>;
+
+function preGenerateIdentities(peerIds: string[]): Identities {
+  const identities: Identities = new Map();
+  for (const id of peerIds) identities.set(id, generateSigningKeyPair());
+  return identities;
+}
+
+function buildPeer(
+  peerId: string,
+  knownPeerIds: string[],
+  docKey: Uint8Array,
+  identities: Identities
+): Peer {
+  const identity = identities.get(peerId);
+  if (!identity) throw new Error(`missing identity for ${peerId}`);
+  const knownPeers = new Map<string, Uint8Array>();
+  for (const knownId of knownPeerIds) {
+    const knownIdentity = identities.get(knownId);
+    if (!knownIdentity) throw new Error(`peer ${peerId} lists unknown peer ${knownId}`);
+    knownPeers.set(knownId, knownIdentity.publicKey);
+  }
   const keyring: MeshKeyring = {
     identity,
-    knownPeers: new Map(
-      knownPeerIds.map((id) => [id, new Uint8Array(32)] as [string, Uint8Array])
-    ),
+    knownPeers,
     documentKeys: new Map([[DEFAULT_MESH_KEY_ID, docKey]]),
     revokedPeers: new Set(),
   };
@@ -69,7 +88,7 @@ function buildPeer(peerId: string, knownPeerIds: string[], docKey: Uint8Array): 
   Object.assign(webrtc, { signaling });
   const mesh = new MeshNetworkAdapter({ base: webrtc, keyring });
   const repo = new Repo({ network: [mesh], peerId: peerId as unknown as PeerId });
-  return { keyring, signaling, webrtc, mesh, repo, peerId };
+  return { identity, keyring, signaling, webrtc, mesh, repo, peerId };
 }
 
 async function shutdown(peer: Peer): Promise<void> {
@@ -80,11 +99,12 @@ async function shutdown(peer: Peer): Promise<void> {
 describe("MeshWebRTCAdapter in multi-peer topologies", () => {
   test("three-peer mesh: every pair connects and writes converge on all three", async () => {
     const docKey = generateDocumentKey();
+    const identities = preGenerateIdentities(["peer-a", "peer-b", "peer-c"]);
     // peer-c > peer-b > peer-a under string comparison — so peer-c
     // initiates to both, peer-b initiates to peer-a.
-    const a = buildPeer("peer-a", ["peer-b", "peer-c"], docKey);
-    const b = buildPeer("peer-b", ["peer-a", "peer-c"], docKey);
-    const c = buildPeer("peer-c", ["peer-a", "peer-b"], docKey);
+    const a = buildPeer("peer-a", ["peer-b", "peer-c"], docKey, identities);
+    const b = buildPeer("peer-b", ["peer-a", "peer-c"], docKey, identities);
+    const c = buildPeer("peer-c", ["peer-a", "peer-b"], docKey, identities);
 
     await a.signaling.connect();
     await b.signaling.connect();
@@ -131,10 +151,11 @@ describe("MeshWebRTCAdapter in multi-peer topologies", () => {
     const docKey = generateDocumentKey();
     // A and B are pairwise trusted. D joins the signalling server with
     // a completely unrelated peer id and is in no one's knownPeers.
-    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
-    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    const identities = preGenerateIdentities(["peer-alpha", "peer-beta", "peer-delta"]);
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey, identities);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey, identities);
     const dDocKey = generateDocumentKey(); // D does not share A/B's document key either
-    const d = buildPeer("peer-delta", [], dDocKey);
+    const d = buildPeer("peer-delta", [], dDocKey, identities);
 
     await a.signaling.connect();
     await b.signaling.connect();

--- a/tests/browser/mesh-webrtc-multi-peer.browser.ts
+++ b/tests/browser/mesh-webrtc-multi-peer.browser.ts
@@ -1,0 +1,170 @@
+/**
+ * Browser tests for MeshWebRTCAdapter in multi-peer topologies.
+ *
+ * Proves that the peer-discovery protocol scales beyond a pair:
+ *
+ *   - A three-peer mesh converges on three WebRTC connections (one per
+ *     ordered pair) and documents written on any peer propagate to the
+ *     other two without manual reconnection.
+ *   - A bystander that joins the signalling server but is in no one's
+ *     `knownPeers` does not cause any offer attempts and does not
+ *     disrupt the pair that is already trusted.
+ *
+ * Same harness as mesh-webrtc-late-join.browser.ts — see that file for
+ * the detailed comment on peer construction and the signalling URL
+ * injection.
+ */
+
+import { type PeerId, Repo } from "@automerge/automerge-repo";
+import { generateDocumentKey } from "../../src/shared/lib/encryption";
+import {
+  DEFAULT_MESH_KEY_ID,
+  type MeshKeyring,
+  MeshNetworkAdapter,
+} from "../../src/shared/lib/mesh-network-adapter";
+import { MeshSignalingClient } from "../../src/shared/lib/mesh-signaling-client";
+import { MeshWebRTCAdapter } from "../../src/shared/lib/mesh-webrtc-adapter";
+import { generateSigningKeyPair } from "../../src/shared/lib/signing";
+import { describe, done, expect, test, waitFor } from "../../tools/test/src/browser/harness";
+
+const SIGNALING_URL = process.env.SIGNALING_URL ?? "ws://127.0.0.1:39000/polly/signaling";
+
+type Doc = {
+  title: string;
+  count: number;
+};
+
+interface Peer {
+  keyring: MeshKeyring;
+  signaling: MeshSignalingClient;
+  webrtc: MeshWebRTCAdapter;
+  mesh: MeshNetworkAdapter;
+  repo: Repo;
+  peerId: string;
+}
+
+function buildPeer(peerId: string, knownPeerIds: string[], docKey: Uint8Array): Peer {
+  const identity = generateSigningKeyPair();
+  const keyring: MeshKeyring = {
+    identity,
+    knownPeers: new Map(
+      knownPeerIds.map((id) => [id, new Uint8Array(32)] as [string, Uint8Array])
+    ),
+    documentKeys: new Map([[DEFAULT_MESH_KEY_ID, docKey]]),
+    revokedPeers: new Set(),
+  };
+  const webrtc = new MeshWebRTCAdapter({
+    signaling: null as unknown as MeshSignalingClient,
+    peerId,
+    knownPeerIds,
+  });
+  const signaling = new MeshSignalingClient({
+    url: SIGNALING_URL,
+    peerId,
+    onSignal: (from, payload) => webrtc.handleSignal(from, payload),
+    onPeersPresent: (ids) => webrtc.handlePeersPresent(ids),
+    onPeerJoined: (id) => webrtc.handlePeerJoined(id),
+    onPeerLeft: (id) => webrtc.handlePeerLeft(id),
+  });
+  Object.assign(webrtc, { signaling });
+  const mesh = new MeshNetworkAdapter({ base: webrtc, keyring });
+  const repo = new Repo({ network: [mesh], peerId: peerId as unknown as PeerId });
+  return { keyring, signaling, webrtc, mesh, repo, peerId };
+}
+
+async function shutdown(peer: Peer): Promise<void> {
+  await peer.repo.shutdown();
+  peer.signaling.close();
+}
+
+describe("MeshWebRTCAdapter in multi-peer topologies", () => {
+  test("three-peer mesh: every pair connects and writes converge on all three", async () => {
+    const docKey = generateDocumentKey();
+    // peer-c > peer-b > peer-a under string comparison — so peer-c
+    // initiates to both, peer-b initiates to peer-a.
+    const a = buildPeer("peer-a", ["peer-b", "peer-c"], docKey);
+    const b = buildPeer("peer-b", ["peer-a", "peer-c"], docKey);
+    const c = buildPeer("peer-c", ["peer-a", "peer-b"], docKey);
+
+    await a.signaling.connect();
+    await b.signaling.connect();
+    await c.signaling.connect();
+
+    console.log("[test] waiting for each peer to reach two Automerge peers");
+    await waitFor(
+      () => a.repo.peers.length === 2 && b.repo.peers.length === 2 && c.repo.peers.length === 2,
+      15000
+    );
+
+    // Each adapter should have exactly two slots — one for each of the
+    // two other peers. No duplicates from glare.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(a.webrtc.peerSlotCount()).toBe(2);
+    expect(b.webrtc.peerSlotCount()).toBe(2);
+    expect(c.webrtc.peerSlotCount()).toBe(2);
+
+    const handleA = a.repo.create<Doc>({ title: "three-peer", count: 1 });
+    await handleA.whenReady();
+    const handleB = await b.repo.find<Doc>(handleA.documentId);
+    const handleC = await c.repo.find<Doc>(handleA.documentId);
+    await waitFor(() => {
+      try {
+        return handleB.doc().title === "three-peer" && handleC.doc().title === "three-peer";
+      } catch {
+        return false;
+      }
+    }, 10000);
+
+    handleC.change((d) => {
+      d.count = 99;
+    });
+    await waitFor(() => handleA.doc().count === 99 && handleB.doc().count === 99, 10000);
+    expect(handleA.doc().count).toBe(99);
+    expect(handleB.doc().count).toBe(99);
+
+    await shutdown(a);
+    await shutdown(b);
+    await shutdown(c);
+  });
+
+  test("stranger in the lobby: an untrusted peer does not derail trusted pairs", async () => {
+    const docKey = generateDocumentKey();
+    // A and B are pairwise trusted. D joins the signalling server with
+    // a completely unrelated peer id and is in no one's knownPeers.
+    const a = buildPeer("peer-alpha", ["peer-beta"], docKey);
+    const b = buildPeer("peer-beta", ["peer-alpha"], docKey);
+    const dDocKey = generateDocumentKey(); // D does not share A/B's document key either
+    const d = buildPeer("peer-delta", [], dDocKey);
+
+    await a.signaling.connect();
+    await b.signaling.connect();
+    await d.signaling.connect();
+
+    await waitFor(() => a.repo.peers.length > 0 && b.repo.peers.length > 0, 10000);
+
+    // D is joined but should never have ended up in anyone's slot map,
+    // nor should D have created a slot of its own.
+    await new Promise((r) => setTimeout(r, 500));
+    expect(d.webrtc.peerSlotCount()).toBe(0);
+    expect(a.webrtc.peerSlotCount()).toBe(1);
+    expect(b.webrtc.peerSlotCount()).toBe(1);
+
+    const handleA = a.repo.create<Doc>({ title: "no-stranger", count: 7 });
+    await handleA.whenReady();
+    const handleB = await b.repo.find<Doc>(handleA.documentId);
+    await waitFor(() => {
+      try {
+        return handleB.doc().title === "no-stranger";
+      } catch {
+        return false;
+      }
+    }, 10000);
+    expect(handleB.doc().count).toBe(7);
+
+    await shutdown(a);
+    await shutdown(b);
+    await shutdown(d);
+  });
+});
+
+done();

--- a/tests/browser/mesh-webrtc.browser.ts
+++ b/tests/browser/mesh-webrtc.browser.ts
@@ -68,6 +68,9 @@ describe("MeshWebRTCAdapter end-to-end in a real browser", () => {
       url: SIGNALING_URL,
       peerId: "peer-a",
       onSignal: (from, payload) => webrtcA.handleSignal(from, payload),
+      onPeersPresent: (ids) => webrtcA.handlePeersPresent(ids),
+      onPeerJoined: (id) => webrtcA.handlePeerJoined(id),
+      onPeerLeft: (id) => webrtcA.handlePeerLeft(id),
     });
 
     // Replace the signaling reference via Object.assign since the field is readonly
@@ -83,6 +86,9 @@ describe("MeshWebRTCAdapter end-to-end in a real browser", () => {
       url: SIGNALING_URL,
       peerId: "peer-b",
       onSignal: (from, payload) => webrtcB.handleSignal(from, payload),
+      onPeersPresent: (ids) => webrtcB.handlePeersPresent(ids),
+      onPeerJoined: (id) => webrtcB.handlePeerJoined(id),
+      onPeerLeft: (id) => webrtcB.handlePeerLeft(id),
     });
     Object.assign(webrtcB, { signaling: signalingB });
 

--- a/tests/integration/signaling-peer-notifications.test.ts
+++ b/tests/integration/signaling-peer-notifications.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Integration test for the signalling server's peer-discovery protocol.
+ *
+ * Spins up a real Elysia app on a random port with the signalling
+ * plugin mounted, connects raw WebSocket clients, and verifies the
+ * frames emitted by the server through the lifecycle of a peer:
+ *
+ *   - On join, the newcomer receives `{type:"peers-present", peerIds:[...]}`
+ *     once, listing every peer already joined at that moment.
+ *   - On join, every incumbent receives `{type:"peer-joined", peerId:<newcomer>}`.
+ *   - On close, every remaining incumbent receives
+ *     `{type:"peer-left", peerId:<departed>}`.
+ *
+ * These frames are what turns the adapter's one-shot startup sweep into
+ * a fully reactive discovery flow. Together with the existing
+ * signal/error protocol (covered by signaling-server.test.ts) they are
+ * the complete server-to-client surface.
+ *
+ * The test uses Bun's native WebSocket for the clients, same as the
+ * existing signalling-server suite.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { signalingServer } from "@/elysia/signaling-server-plugin";
+
+let pendingApps: Array<{ stop: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  for (const app of pendingApps) {
+    try {
+      await app.stop();
+    } catch {
+      // best effort
+    }
+  }
+  pendingApps = [];
+}, 10000);
+
+function pickPort(): number {
+  return 30000 + Math.floor(Math.random() * 10000);
+}
+
+function mountSignalingApp(port: number): { url: string } {
+  const app = new Elysia().use(signalingServer({ path: "/polly/signaling" })).listen(port);
+  pendingApps.push({
+    stop: async () => {
+      (app as unknown as { server?: { stop?: (force?: boolean) => void } }).server?.stop?.(true);
+    },
+  });
+  return { url: `ws://127.0.0.1:${port}/polly/signaling` };
+}
+
+interface SignalingClient {
+  send: (msg: unknown) => void;
+  next: () => Promise<unknown>;
+  drain: () => unknown[];
+  close: () => void;
+}
+
+function openSignalingClient(url: string): Promise<SignalingClient> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const queue: unknown[] = [];
+    const waiters: Array<(msg: unknown) => void> = [];
+
+    ws.addEventListener("open", () => {
+      resolve({
+        send: (msg) => ws.send(typeof msg === "string" ? msg : JSON.stringify(msg)),
+        next: () =>
+          new Promise<unknown>((r) => {
+            if (queue.length > 0) r(queue.shift());
+            else waiters.push(r);
+          }),
+        drain: () => {
+          const copy = queue.slice();
+          queue.length = 0;
+          return copy;
+        },
+        close: () => ws.close(),
+      });
+    });
+
+    ws.addEventListener("message", (ev) => {
+      const data = typeof ev.data === "string" ? JSON.parse(ev.data) : ev.data;
+      const waiter = waiters.shift();
+      if (waiter) waiter(data);
+      else queue.push(data);
+    });
+
+    ws.addEventListener("error", reject);
+  });
+}
+
+async function waitForMessage(
+  client: { next: () => Promise<unknown> },
+  timeoutMs = 1000
+): Promise<unknown> {
+  return Promise.race([
+    client.next(),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`Timed out waiting for message after ${timeoutMs}ms`)),
+        timeoutMs
+      )
+    ),
+  ]);
+}
+
+interface PeersPresentFrame {
+  type: "peers-present";
+  peerIds: string[];
+}
+
+interface PeerJoinedFrame {
+  type: "peer-joined";
+  peerId: string;
+}
+
+interface PeerLeftFrame {
+  type: "peer-left";
+  peerId: string;
+}
+
+function isPeersPresent(value: unknown): value is PeersPresentFrame {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    (value as { type: unknown }).type === "peers-present"
+  );
+}
+
+function isPeerJoined(value: unknown): value is PeerJoinedFrame {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    (value as { type: unknown }).type === "peer-joined"
+  );
+}
+
+function isPeerLeft(value: unknown): value is PeerLeftFrame {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    (value as { type: unknown }).type === "peer-left"
+  );
+}
+
+describe("signalingServer peer-discovery frames", () => {
+  test("a lone newcomer receives peers-present with an empty list", async () => {
+    const { url } = mountSignalingApp(pickPort());
+    const alice = await openSignalingClient(url);
+
+    alice.send({ type: "join", peerId: "peer-alice" });
+    const first = await waitForMessage(alice);
+
+    expect(isPeersPresent(first)).toBeTruthy();
+    if (!isPeersPresent(first)) throw new Error("type narrowing");
+    expect(first.peerIds).toEqual([]);
+
+    alice.close();
+  });
+
+  test("a second joiner receives peers-present listing the incumbent", async () => {
+    const { url } = mountSignalingApp(pickPort());
+    const alice = await openSignalingClient(url);
+    alice.send({ type: "join", peerId: "peer-alice" });
+    await waitForMessage(alice); // drain alice's own peers-present
+
+    const bob = await openSignalingClient(url);
+    bob.send({ type: "join", peerId: "peer-bob" });
+
+    const bobFirst = await waitForMessage(bob);
+    expect(isPeersPresent(bobFirst)).toBeTruthy();
+    if (!isPeersPresent(bobFirst)) throw new Error("type narrowing");
+    expect(bobFirst.peerIds).toEqual(["peer-alice"]);
+
+    alice.close();
+    bob.close();
+  });
+
+  test("an incumbent receives peer-joined when a new peer joins", async () => {
+    const { url } = mountSignalingApp(pickPort());
+    const alice = await openSignalingClient(url);
+    alice.send({ type: "join", peerId: "peer-alice" });
+    await waitForMessage(alice); // drain alice's own peers-present
+
+    const bob = await openSignalingClient(url);
+    bob.send({ type: "join", peerId: "peer-bob" });
+
+    const aliceNotif = await waitForMessage(alice);
+    expect(isPeerJoined(aliceNotif)).toBeTruthy();
+    if (!isPeerJoined(aliceNotif)) throw new Error("type narrowing");
+    expect(aliceNotif.peerId).toBe("peer-bob");
+
+    alice.close();
+    bob.close();
+  });
+
+  test("a three-peer sequence delivers peers-present and peer-joined as expected", async () => {
+    const { url } = mountSignalingApp(pickPort());
+
+    const alice = await openSignalingClient(url);
+    alice.send({ type: "join", peerId: "peer-alice" });
+    const aliceFirst = await waitForMessage(alice);
+    expect(isPeersPresent(aliceFirst)).toBeTruthy();
+    if (!isPeersPresent(aliceFirst)) throw new Error("type narrowing");
+    expect(aliceFirst.peerIds).toEqual([]);
+
+    const bob = await openSignalingClient(url);
+    bob.send({ type: "join", peerId: "peer-bob" });
+    const bobFirst = await waitForMessage(bob);
+    expect(isPeersPresent(bobFirst)).toBeTruthy();
+    if (!isPeersPresent(bobFirst)) throw new Error("type narrowing");
+    expect(bobFirst.peerIds).toEqual(["peer-alice"]);
+
+    const aliceNotifForBob = await waitForMessage(alice);
+    expect(isPeerJoined(aliceNotifForBob)).toBeTruthy();
+    if (!isPeerJoined(aliceNotifForBob)) throw new Error("type narrowing");
+    expect(aliceNotifForBob.peerId).toBe("peer-bob");
+
+    const carol = await openSignalingClient(url);
+    carol.send({ type: "join", peerId: "peer-carol" });
+    const carolFirst = await waitForMessage(carol);
+    expect(isPeersPresent(carolFirst)).toBeTruthy();
+    if (!isPeersPresent(carolFirst)) throw new Error("type narrowing");
+    expect(carolFirst.peerIds.sort()).toEqual(["peer-alice", "peer-bob"].sort());
+
+    const aliceNotifForCarol = await waitForMessage(alice);
+    expect(isPeerJoined(aliceNotifForCarol)).toBeTruthy();
+    if (!isPeerJoined(aliceNotifForCarol)) throw new Error("type narrowing");
+    expect(aliceNotifForCarol.peerId).toBe("peer-carol");
+
+    const bobNotifForCarol = await waitForMessage(bob);
+    expect(isPeerJoined(bobNotifForCarol)).toBeTruthy();
+    if (!isPeerJoined(bobNotifForCarol)) throw new Error("type narrowing");
+    expect(bobNotifForCarol.peerId).toBe("peer-carol");
+
+    alice.close();
+    bob.close();
+    carol.close();
+  });
+
+  test("the newcomer never receives a peer-joined for its own id", async () => {
+    const { url } = mountSignalingApp(pickPort());
+    const dave = await openSignalingClient(url);
+    dave.send({ type: "join", peerId: "peer-dave" });
+    await waitForMessage(dave); // peers-present
+
+    // Give the server time to process the join and emit any subsequent
+    // frames. The test passes if nothing else arrives.
+    await new Promise((r) => setTimeout(r, 150));
+    const unexpected = dave.drain();
+    expect(unexpected).toEqual([]);
+
+    dave.close();
+  });
+
+  test("incumbents receive peer-left when a joined peer closes its socket", async () => {
+    const { url } = mountSignalingApp(pickPort());
+    const alice = await openSignalingClient(url);
+    alice.send({ type: "join", peerId: "peer-alice" });
+    await waitForMessage(alice); // peers-present
+
+    const bob = await openSignalingClient(url);
+    bob.send({ type: "join", peerId: "peer-bob" });
+    await waitForMessage(bob); // peers-present
+    await waitForMessage(alice); // peer-joined bob
+
+    bob.close();
+
+    const aliceNotif = await waitForMessage(alice, 2000);
+    expect(isPeerLeft(aliceNotif)).toBeTruthy();
+    if (!isPeerLeft(aliceNotif)) throw new Error("type narrowing");
+    expect(aliceNotif.peerId).toBe("peer-bob");
+
+    alice.close();
+  });
+
+  test("a peer that never joined does not trigger peer-left on close", async () => {
+    const { url } = mountSignalingApp(pickPort());
+    const alice = await openSignalingClient(url);
+    alice.send({ type: "join", peerId: "peer-alice" });
+    await waitForMessage(alice); // peers-present
+
+    // A bystander connects but never sends `join`. On close, no peer-left
+    // should go to Alice because the bystander was never a joined peer.
+    const bystander = await openSignalingClient(url);
+    bystander.close();
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(alice.drain()).toEqual([]);
+
+    alice.close();
+  });
+
+  test("the existing relay/error contract is unchanged under the extended protocol", async () => {
+    const { url } = mountSignalingApp(pickPort());
+    const eve = await openSignalingClient(url);
+    eve.send({ type: "join", peerId: "peer-eve" });
+    await waitForMessage(eve); // peers-present
+
+    eve.send({
+      type: "signal",
+      peerId: "peer-eve",
+      targetPeerId: "peer-nobody",
+      payload: { ice: "candidate" },
+    });
+
+    const reply = (await waitForMessage(eve)) as unknown as { type: string; reason: string };
+    expect(reply.type).toBe("error");
+    expect(reply.reason).toBe("unknown-target");
+
+    eve.close();
+  });
+});

--- a/tests/integration/signaling-server.test.ts
+++ b/tests/integration/signaling-server.test.ts
@@ -90,6 +90,28 @@ async function waitForMessage(
   ]);
 }
 
+// Drain peer-discovery frames (peers-present, peer-joined, peer-left)
+// so tests that assert on the signal/error contract are not tripped up
+// by the additive discovery protocol covered in
+// signaling-peer-notifications.test.ts.
+async function waitForNonDiscoveryMessage(
+  client: { next: () => Promise<unknown> },
+  timeoutMs = 1000
+): Promise<unknown> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const msg = await waitForMessage(client, deadline - Date.now());
+    const type =
+      typeof msg === "object" && msg !== null && "type" in msg
+        ? (msg as { type: unknown }).type
+        : undefined;
+    if (type !== "peers-present" && type !== "peer-joined" && type !== "peer-left") {
+      return msg;
+    }
+  }
+  throw new Error(`waitForNonDiscoveryMessage timed out after ${timeoutMs}ms`);
+}
+
 describe("signalingServer plugin", () => {
   test("relays a signal from peer A to peer B after both have joined", async () => {
     const port = pickPort();
@@ -117,7 +139,7 @@ describe("signalingServer plugin", () => {
       payload: { sdp: "v=0\r\n…" },
     });
 
-    const received = (await waitForMessage(bob)) as unknown as {
+    const received = (await waitForNonDiscoveryMessage(bob)) as unknown as {
       type: string;
       peerId: string;
       targetPeerId: string;
@@ -179,7 +201,7 @@ describe("signalingServer plugin", () => {
       payload: { ice: "candidate" },
     });
 
-    const reply = (await waitForMessage(dave)) as unknown as {
+    const reply = (await waitForNonDiscoveryMessage(dave)) as unknown as {
       type: string;
       reason: string;
       targetPeerId: string;
@@ -216,7 +238,7 @@ describe("signalingServer plugin", () => {
       payload: { evil: true },
     });
 
-    const received = (await waitForMessage(frank)) as unknown as { peerId: string };
+    const received = (await waitForNonDiscoveryMessage(frank)) as unknown as { peerId: string };
     // Server replaces with the authenticated peer id.
     expect(received.peerId).toBe("peer-eve");
 
@@ -254,7 +276,10 @@ describe("signalingServer plugin", () => {
       payload: {},
     });
 
-    const reply = (await waitForMessage(grace)) as unknown as { type: string; reason: string };
+    const reply = (await waitForNonDiscoveryMessage(grace)) as unknown as {
+      type: string;
+      reason: string;
+    };
     expect(reply.type).toBe("error");
     expect(reply.reason).toBe("unknown-target");
 

--- a/tests/unit/adapters.test.ts
+++ b/tests/unit/adapters.test.ts
@@ -44,7 +44,6 @@ test("RuntimeAdapter interface - onMessage listener", async () => {
 
   // Simulate incoming message
   for (const listener of mockChrome.runtime._messageListeners) {
-    // biome-ignore lint/suspicious/noEmptyBlockStatements: Empty response handler for test
     listener({ type: "TEST" }, {} as unknown as MessageSender, () => {});
   }
 

--- a/tests/unit/mesh-webrtc-adapter-peer-joined.test.ts
+++ b/tests/unit/mesh-webrtc-adapter-peer-joined.test.ts
@@ -29,9 +29,9 @@
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
-import {
-  type MeshSignalingClient,
-  type MeshSignalingClientOptions,
+import type {
+  MeshSignalingClient,
+  MeshSignalingClientOptions,
 } from "@/shared/lib/mesh-signaling-client";
 import { MeshWebRTCAdapter } from "@/shared/lib/mesh-webrtc-adapter";
 

--- a/tests/unit/mesh-webrtc-adapter-peer-joined.test.ts
+++ b/tests/unit/mesh-webrtc-adapter-peer-joined.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for MeshWebRTCAdapter's peer-discovery dispatch.
+ *
+ * The adapter gains three new public methods that the signalling client
+ * will call on `peers-present`, `peer-joined`, and `peer-left` frames:
+ *
+ *   - handlePeerJoined(peerId): consider a single newly-announced peer.
+ *   - handlePeersPresent(peerIds): consider a list of already-joined peers.
+ *   - handlePeerLeft(peerId): tear down any slot for a peer that left.
+ *
+ * The first two must apply the same filter: only initiate an SDP offer
+ * when (a) the peer is in `knownPeerIds`, (b) no slot already exists for
+ * it, and (c) the tie-break rule — `this.peerId > remotePeerId` under
+ * string comparison — designates this side as the initiator.
+ *
+ * The tie-break direction matches the existing glare-resolution logic
+ * in `handleOffer`: the lexicographically higher peer id is the one
+ * whose initiator survives any race. Extending the same rule to the
+ * pre-offer decision eliminates the glare entirely for the common case
+ * where both sides learn of each other at roughly the same time.
+ *
+ * handlePeerLeft is the counterpart: when a peer disconnects from the
+ * signalling server, its entry in our slot map is evicted so that a
+ * subsequent rejoin (which fires peer-joined again) creates a fresh
+ * slot against the reincarnated peer.
+ *
+ * These tests stub the signalling client and the RTC peer connection,
+ * so they run in plain bun:test with no browser.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  type MeshSignalingClient,
+  type MeshSignalingClientOptions,
+} from "@/shared/lib/mesh-signaling-client";
+import { MeshWebRTCAdapter } from "@/shared/lib/mesh-webrtc-adapter";
+
+// ─── Fake WebRTC implementation ──────────────────────────────────────────────
+// Enough surface for createInitiatingSlot → initiateOffer to run to the
+// point of calling signaling.sendSignal with the offer, then stop. No
+// actual SDP negotiation happens.
+
+class FakeDataChannel {
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: ArrayBuffer | Uint8Array }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  readyState = "connecting";
+  close(): void {
+    this.readyState = "closed";
+    this.onclose?.();
+  }
+  send(_: ArrayBuffer | Uint8Array): void {}
+}
+
+class FakePeerConnection {
+  onicecandidate: ((ev: { candidate: unknown }) => void) | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  ondatachannel: ((ev: { channel: FakeDataChannel }) => void) | null = null;
+  connectionState = "new";
+  createDataChannel(_label: string, _options: unknown): FakeDataChannel {
+    return new FakeDataChannel();
+  }
+  async createOffer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "offer", sdp: "v=0\r\nfake\r\n" };
+  }
+  async setLocalDescription(_desc: RTCSessionDescriptionInit): Promise<void> {}
+  async setRemoteDescription(_desc: RTCSessionDescriptionInit): Promise<void> {}
+  async createAnswer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "answer", sdp: "v=0\r\nfake\r\n" };
+  }
+  async addIceCandidate(_candidate: unknown): Promise<void> {}
+  close(): void {
+    this.connectionState = "closed";
+    this.onconnectionstatechange?.();
+  }
+}
+
+// ─── Signalling client stub ──────────────────────────────────────────────────
+
+interface SentSignal {
+  targetPeerId: string;
+  payload: unknown;
+}
+
+function createSignalingStub(peerId: string): {
+  client: MeshSignalingClient;
+  sent: SentSignal[];
+  options: MeshSignalingClientOptions;
+} {
+  const sent: SentSignal[] = [];
+  const options: MeshSignalingClientOptions = {
+    url: "ws://stub",
+    peerId,
+    onSignal: () => {},
+  };
+  const client = {
+    url: options.url,
+    peerId,
+    isConnected: true,
+    sendSignal(targetPeerId: string, payload: unknown): boolean {
+      sent.push({ targetPeerId, payload });
+      return true;
+    },
+    connect: async (): Promise<void> => {},
+    close: (): void => {},
+  } as unknown as MeshSignalingClient;
+  return { client, sent, options };
+}
+
+// ─── Adapter factory ─────────────────────────────────────────────────────────
+
+function buildAdapter(
+  localPeerId: string,
+  knownPeerIds: string[]
+): { adapter: MeshWebRTCAdapter; sent: SentSignal[] } {
+  const { client, sent } = createSignalingStub(localPeerId);
+  const adapter = new MeshWebRTCAdapter({
+    signaling: client,
+    peerId: localPeerId,
+    knownPeerIds,
+    RTCPeerConnection: FakePeerConnection as unknown as typeof RTCPeerConnection,
+  });
+  return { adapter, sent };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("MeshWebRTCAdapter peer-discovery dispatch", () => {
+  // Tie-break rule: the lexicographically higher peer id is the initiator.
+  // "peer-b" > "peer-a", so "peer-b" initiates toward "peer-a".
+
+  describe("handlePeerJoined", () => {
+    let adapter: MeshWebRTCAdapter;
+    let sent: SentSignal[];
+
+    beforeEach(() => {
+      const built = buildAdapter("peer-b", ["peer-a"]);
+      adapter = built.adapter;
+      sent = built.sent;
+    });
+
+    test("initiates an offer when the remote peer is known and we are the higher id", async () => {
+      adapter.handlePeerJoined("peer-a");
+      // initiateOffer runs an async chain; flush microtasks.
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.targetPeerId).toBe("peer-a");
+      const payload = sent[0]?.payload as { kind?: string };
+      expect(payload.kind).toBe("offer");
+    });
+
+    test("is a no-op when we are the lower id (remote will initiate toward us)", async () => {
+      const { adapter: lowerAdapter, sent: lowerSent } = buildAdapter("peer-a", ["peer-b"]);
+      lowerAdapter.handlePeerJoined("peer-b");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(lowerSent).toEqual([]);
+    });
+
+    test("is a no-op when the peer is not in knownPeerIds", async () => {
+      adapter.handlePeerJoined("peer-c");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toEqual([]);
+    });
+
+    test("is a no-op when a slot for that peer already exists", async () => {
+      adapter.handlePeerJoined("peer-a");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toHaveLength(1);
+
+      adapter.handlePeerJoined("peer-a");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toHaveLength(1);
+    });
+
+    test("is a no-op when the announced peer is our own id", async () => {
+      adapter.handlePeerJoined("peer-b");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toEqual([]);
+    });
+  });
+
+  describe("handlePeersPresent", () => {
+    test("fans out to each known peer where we are the higher id", async () => {
+      // Local "peer-m" against three knownPeers: one lower, one higher, one unknown.
+      const { adapter, sent } = buildAdapter("peer-m", ["peer-a", "peer-z", "peer-stranger"]);
+      adapter.handlePeersPresent(["peer-a", "peer-z", "peer-unpaired"]);
+      await new Promise((r) => setTimeout(r, 0));
+      // Only "peer-a" qualifies: it's in knownPeers and we (peer-m) are higher.
+      // "peer-z" is higher than us, so it would initiate toward us.
+      // "peer-unpaired" is not in knownPeers.
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.targetPeerId).toBe("peer-a");
+    });
+
+    test("is a no-op for an empty list", async () => {
+      const { adapter, sent } = buildAdapter("peer-m", ["peer-a"]);
+      adapter.handlePeersPresent([]);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toEqual([]);
+    });
+
+    test("does not duplicate when a slot is already present for one of the peers", async () => {
+      const { adapter, sent } = buildAdapter("peer-m", ["peer-a", "peer-b"]);
+      adapter.handlePeerJoined("peer-a");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toHaveLength(1);
+
+      adapter.handlePeersPresent(["peer-a", "peer-b"]);
+      await new Promise((r) => setTimeout(r, 0));
+      // peer-a is already slotted → skipped; peer-b initiates.
+      expect(sent).toHaveLength(2);
+      expect(sent[1]?.targetPeerId).toBe("peer-b");
+    });
+  });
+
+  describe("handlePeerLeft", () => {
+    test("evicts the slot for a known peer that has left", async () => {
+      const { adapter } = buildAdapter("peer-m", ["peer-a"]);
+      adapter.handlePeerJoined("peer-a");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(adapter.peerSlotCount()).toBe(1);
+
+      adapter.handlePeerLeft("peer-a");
+      expect(adapter.peerSlotCount()).toBe(0);
+    });
+
+    test("is a no-op for a peer that was never slotted", () => {
+      const { adapter } = buildAdapter("peer-m", ["peer-a"]);
+      adapter.handlePeerLeft("peer-stranger");
+      expect(adapter.peerSlotCount()).toBe(0);
+    });
+
+    test("a subsequent handlePeerJoined after handlePeerLeft creates a fresh slot", async () => {
+      const { adapter, sent } = buildAdapter("peer-m", ["peer-a"]);
+      adapter.handlePeerJoined("peer-a");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sent).toHaveLength(1);
+
+      adapter.handlePeerLeft("peer-a");
+      adapter.handlePeerJoined("peer-a");
+      await new Promise((r) => setTimeout(r, 0));
+      // A second offer fires because the slot was evicted in between.
+      expect(sent).toHaveLength(2);
+      expect(sent[1]?.targetPeerId).toBe("peer-a");
+    });
+  });
+
+  describe("peerSlotCount helper", () => {
+    test("reports the current number of initiating slots", async () => {
+      const { adapter } = buildAdapter("peer-m", ["peer-a", "peer-b"]);
+      expect(adapter.peerSlotCount()).toBe(0);
+      adapter.handlePeerJoined("peer-a");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(adapter.peerSlotCount()).toBe(1);
+      adapter.handlePeerJoined("peer-b");
+      await new Promise((r) => setTimeout(r, 0));
+      expect(adapter.peerSlotCount()).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #57. Partially unblocks AlexJeffcott/fairfox#6.

## Problem

`MeshWebRTCAdapter.connect()` fired its SDP offers once at the moment Automerge's `NetworkSubsystem` called `connect()`. If a `knownPeerId` was not currently joined to the signalling server at that instant, the offer landed on an empty slot, the server returned `{type:"error", reason:"unknown-target"}`, and the adapter never retried. The signalling protocol also carried no `peer-joined` hint an absent peer had come online, so the missing peer was only discovered if one device was later reloaded while the other was already joined.

## Shape of the fix

Additive on the wire, covered by tests at three tiers.

### Signalling protocol — three new server-to-client frames

- `peers-present: [peerId…]` — sent once to a newcomer immediately after its `join`, listing every peer already joined.
- `peer-joined: peerId` — broadcast to every incumbent when a new peer joins.
- `peer-left: peerId` — broadcast to every remaining incumbent when a joined peer's socket closes.

Existing clients and servers that do not emit or parse the new frames degrade to today's behaviour — no breaking change on the wire.

### Client-side plumbing

`MeshSignalingClient` parses the three new types into three optional callbacks — `onPeersPresent`, `onPeerJoined`, `onPeerLeft`. `MeshWebRTCAdapter` gains `handlePeerJoined`, `handlePeersPresent`, and `handlePeerLeft`. The initiator entry points apply the same filter: peer in `knownPeerIds`, no existing slot, and our peer id compares lexicographically greater than the remote's. That matches the existing glare-resolution rule in `handleOffer`, so the pre-offer filter eliminates the glare pathway entirely for the common simultaneous-join case. `handlePeerLeft` tears down any slot we hold for the departed peer so a subsequent rejoin builds a fresh connection instead of racing WebRTC's own ICE-timeout eviction.

The old unconditional startup sweep in `connect()` is removed — discovery flows exclusively through the notification frames. `createMeshClient` wires the three new callbacks through automatically, so real consumers pick up the protocol with no code change.

## Tests

All three tiers now green. They were red in the prior commit on this branch (`Encode the mesh-transport late-join acceptance as red tests`) and the current commit turns them green.

- **Integration**: `tests/integration/signaling-peer-notifications.test.ts` — 8 tests drive the server's peer-discovery surface directly through raw WebSocket clients.
- **Unit**: `tests/unit/mesh-webrtc-adapter-peer-joined.test.ts` — 12 tests exercise the three new adapter methods with stubbed signalling and RTC.
- **Browser e2e**: `tests/browser/mesh-webrtc-late-join.browser.ts` (4 scenarios) and `tests/browser/mesh-webrtc-multi-peer.browser.ts` (2 scenarios) walk the full stack through late-join (both orderings), simultaneous-join race, reconnect, three-peer mesh, and a stranger-in-the-lobby test.
- **Regression guards**: the pre-existing `tests/browser/mesh-webrtc.browser.ts` and `tests/browser/blob-store.browser.ts` continue to pass; `tests/integration/signaling-server.test.ts` has a small helper that skips discovery frames before asserting on the signal/error contract it pre-existed to guard.

Run from the repo root:

```sh
bun run lint
bun run typecheck
bun run --cwd tests test
bun tools/test/src/browser/run.ts tests/browser
```

Current state: 640 unit + integration pass, 24 browser pass, zero lint warnings, `tsc --noEmit` clean.

## Follow-ups

- TURN / NAT traversal is tracked separately in #58. This PR is correctness (make discovery reliable); TURN is reach (make the WebRTC connection actually establish across symmetric NATs).
- AlexJeffcott/fairfox#6's acceptance depends on both this PR shipping and fairfox's server adopting the extended protocol. Once this is published the fairfox side can either swap its hand-rolled relay for polly's Elysia plugin or mirror the three frames.

## Drive-bys

- `biome.json` folder-ignore for `.claude/worktrees` drops the trailing `/**` to match biome 2.4's new syntax.
- One stale `biome-ignore` in `tests/unit/adapters.test.ts` whose suppressed rule no longer fires was removed.

Both were pre-existing warnings reported during the 0.26.1 publish. Clearing them keeps the workspace at zero warnings alongside zero errors.