### PR TITLE
Thread the mesh peer id into the Repo in createMeshClient (0.27.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2026-04-18
+
+### Fixed
+
+`createMeshClient` constructed the Automerge `Repo` without passing a
+`peerId`, so Automerge auto-generated a random `peer-xxxxxxx`
+identifier for the local side. `MeshNetworkAdapter` then signed every
+outgoing envelope with that auto-id as its `senderId`, and the remote
+receiver — whose `keyring.knownPeers` was keyed by the mesh peer id
+the application had paired against — dropped the envelope on the
+`knownPeers.get(senderId)` lookup. Mutual trust, WebRTC connection,
+data-channel open — all correct; only the last step, signature
+verification, silently rejected every message. No `$meshState`
+document ever synced through consumers that used the factory.
+
+The fix threads `options.signaling.peerId` into the `Repo` constructor
+so the Automerge local peer id and the mesh peer id are the same
+string. Existing consumers that wired the stack manually and passed
+an explicit `peerId` to `new Repo(...)` were unaffected; the bug
+only ever surfaced for the recommended `createMeshClient` entry point.
+
+A new browser test, `tests/browser/mesh-client-roundtrip.browser.ts`,
+constructs two clients through `createMeshClient` with paired
+keyrings and verifies that a document written on one converges on
+the other. This is the regression guard the existing hand-wired
+`mesh-webrtc.browser.ts` could never have caught, because that test
+passed its own explicit `peerId` to `new Repo()` and so silently
+compensated for the gap.
+
 ## [0.27.0] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/src/shared/lib/mesh-client.ts
+++ b/src/shared/lib/mesh-client.ts
@@ -20,7 +20,7 @@
  * a file-backed keyring store.
  */
 
-import { Repo, type StorageAdapterInterface } from "@automerge/automerge-repo/slim";
+import { type PeerId, Repo, type StorageAdapterInterface } from "@automerge/automerge-repo/slim";
 import type { KeyringStorage } from "./keyring-storage";
 import { DEFAULT_MESH_KEY_ID, type MeshKeyring, MeshNetworkAdapter } from "./mesh-network-adapter";
 import { MeshSignalingClient, type MeshSignalingClientOptions } from "./mesh-signaling-client";
@@ -158,8 +158,16 @@ export async function createMeshClient(options: CreateMeshClientOptions): Promis
     encryptionEnabled,
   });
 
+  // The Repo's peerId MUST match the mesh peer id we signed the keyring
+  // against. Automerge would otherwise auto-generate a random "peer-xxxxx"
+  // identifier, and `MeshNetworkAdapter`'s outgoing envelope would carry
+  // that auto-id as its `senderId` — a value the remote keyring has never
+  // seen and cannot look up in `knownPeers`. Every message would then fail
+  // signature verification silently, and no `$meshState` sync would ever
+  // apply.
   const repo = new Repo({
     network: [networkAdapter],
+    peerId: options.signaling.peerId as unknown as PeerId,
     ...(options.repoStorage !== undefined && { storage: options.repoStorage }),
   });
 

--- a/tests/browser/mesh-client-roundtrip.browser.ts
+++ b/tests/browser/mesh-client-roundtrip.browser.ts
@@ -1,0 +1,95 @@
+/**
+ * Browser test: createMeshClient round-trip.
+ *
+ * Unlike mesh-webrtc.browser.ts — which wires MeshSignalingClient,
+ * MeshWebRTCAdapter, MeshNetworkAdapter, and Repo by hand — this test
+ * builds two clients through the `createMeshClient` factory. The
+ * factory is the documented entry point for consumer applications
+ * (fairfox, lingua, any future mesh-backed app), so it has to be
+ * tested end-to-end with real WebRTC and a real document mutation.
+ *
+ * The acceptance is a document written on client A converging on
+ * client B via the CRDT sync protocol, both sides talking through
+ * `createMeshClient`'s internal wiring. A previous version of the
+ * factory omitted the `peerId` option when constructing the Repo,
+ * which meant Automerge auto-generated a random id that didn't match
+ * the mesh identity the `MeshNetworkAdapter` signed envelopes with;
+ * verification silently dropped every sync message and this test
+ * would have caught that by failing on non-convergence.
+ *
+ * Runs against the `signalingServer` Elysia plugin that
+ * tools/test/src/browser/run.ts starts on an ephemeral port.
+ */
+
+import { generateDocumentKey } from "../../src/shared/lib/encryption";
+import { createMeshClient } from "../../src/shared/lib/mesh-client";
+import { DEFAULT_MESH_KEY_ID, type MeshKeyring } from "../../src/shared/lib/mesh-network-adapter";
+import { generateSigningKeyPair } from "../../src/shared/lib/signing";
+import { describe, done, expect, test, waitFor } from "../../tools/test/src/browser/harness";
+
+const SIGNALING_URL = process.env.SIGNALING_URL ?? "ws://127.0.0.1:39000/polly/signaling";
+
+interface Doc {
+  title: string;
+  count: number;
+}
+
+describe("createMeshClient end-to-end", () => {
+  test("a document created on one client converges on its peer", async () => {
+    const aIdentity = generateSigningKeyPair();
+    const bIdentity = generateSigningKeyPair();
+    const docKey = generateDocumentKey();
+    const peerA = "peer-client-a";
+    const peerB = "peer-client-b";
+
+    const aKeyring: MeshKeyring = {
+      identity: aIdentity,
+      knownPeers: new Map([[peerB, bIdentity.publicKey]]),
+      documentKeys: new Map([[DEFAULT_MESH_KEY_ID, docKey]]),
+      revokedPeers: new Set(),
+    };
+    const bKeyring: MeshKeyring = {
+      identity: bIdentity,
+      knownPeers: new Map([[peerA, aIdentity.publicKey]]),
+      documentKeys: new Map([[DEFAULT_MESH_KEY_ID, docKey]]),
+      revokedPeers: new Set(),
+    };
+
+    const clientA = await createMeshClient({
+      signaling: { url: SIGNALING_URL, peerId: peerA },
+      keyring: aKeyring,
+    });
+    const clientB = await createMeshClient({
+      signaling: { url: SIGNALING_URL, peerId: peerB },
+      keyring: bKeyring,
+    });
+
+    await waitFor(() => clientA.repo.peers.length > 0 && clientB.repo.peers.length > 0, 10000);
+
+    const handleA = clientA.repo.create<Doc>({ title: "factory-roundtrip", count: 1 });
+    await handleA.whenReady();
+
+    const handleB = await clientB.repo.find<Doc>(handleA.documentId);
+    await waitFor(() => {
+      try {
+        return handleB.doc().title === "factory-roundtrip" && handleB.doc().count === 1;
+      } catch {
+        return false;
+      }
+    }, 10000);
+
+    expect(handleB.doc().title).toBe("factory-roundtrip");
+    expect(handleB.doc().count).toBe(1);
+
+    handleB.change((d) => {
+      d.count = 2;
+    });
+    await waitFor(() => handleA.doc().count === 2, 5000);
+    expect(handleA.doc().count).toBe(2);
+
+    await clientA.close();
+    await clientB.close();
+  });
+});
+
+done();


### PR DESCRIPTION
## Why

`createMeshClient` constructed the Automerge `Repo` without passing a `peerId`, so Automerge auto-generated a random `peer-xxxxxxx` identifier for the local side. `MeshNetworkAdapter` then signed every outgoing envelope with that auto-id as its `senderId`, and the remote receiver — whose `keyring.knownPeers` was keyed by the mesh peer id the application had paired against — dropped the envelope on the `knownPeers.get(senderId)` lookup. Mutual trust, WebRTC connection, data-channel open were all correct; only the last step, signature verification, silently rejected every message. No `$meshState` document ever synced through consumers that used the factory.

Observed against the fairfox deployment. Two paired browsers (desktop + phone) established a WebRTC data channel, the initial Automerge sync handshake round-tripped, but every subsequent sync message landed in `MeshNetworkAdapter.tryUnwrap`'s `!senderKey` branch and was silently dropped. Instrumenting the unwrap path showed `drop: unknown sender "peer-fp8vtou4g" (knownPeers=[7b9ad44d1598b465])` — Automerge's auto-id vs the mesh hex id.

## The fix

One line. `options.signaling.peerId` is threaded into the `Repo` constructor:

```ts
const repo = new Repo({
  network: [networkAdapter],
  peerId: options.signaling.peerId as unknown as PeerId,
  ...(options.repoStorage !== undefined && { storage: options.repoStorage }),
});
```

The Automerge local peer id and the mesh peer id are now the same string. Envelopes verify. Documents converge.

## Regression test

`tests/browser/mesh-client-roundtrip.browser.ts` is the guard that would have caught this on the first go. It wires two clients through `createMeshClient` with paired keyrings, waits for Automerge's peer count to rise on both sides, creates a document on client A, asserts convergence on client B, mutates on B, asserts convergence back on A. Same harness and same signalling-server reference plugin as the other browser tests.

The existing `mesh-webrtc.browser.ts` could never have caught this. That test wires `MeshSignalingClient + MeshWebRTCAdapter + MeshNetworkAdapter + Repo` by hand and passes an explicit `peerId` to `new Repo(...)`, which silently compensated for the factory's gap. Anything downstream of the factory — fairfox, lingua, any future consumer — was uncovered.

Verified the new test fails against the 0.27.0 Repo construction (times out at 15s waiting for convergence) and passes against the 0.27.1 construction.

## Version

Bumped to 0.27.1. Patch because it is a bug fix with no API change; consumers pick up the fix by bumping the pin, no code change required.

## Verification

```sh
bun run lint
bun run typecheck
bun run --cwd tests test
bun tools/test/src/browser/run.ts tests/browser
```

Zero warnings, zero errors, 640/640 unit + integration pass, 25/25 browser pass (the existing 24 plus the new `mesh-client-roundtrip`).