### PR TITLE
Forward Button's data-action-* extras; fix mesh-node.js losing node:fs/promises (0.27.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.2] - 2026-04-18
+
+### Fixed
+
+#### `Button` silently dropped `data-action-*` extras
+
+Consumers that attached additional action payload attributes to
+`<Button>` — `data-action-tid`, `data-action-item-id`,
+`data-action-person`, any `data-action-*` — had those attributes
+dropped during render. `Button` destructured `data-action` explicitly
+and forwarded only that one; the rest were accepted as props by
+TypeScript (the type now declares an index signature for
+``data-action-${string}``) but never reached the underlying element.
+The click bubbled up to the event delegator, the handler fired, and
+`ctx.data` was empty. Every handler that guarded on `if (!ctx.data.tid)
+return;` silently no-ed — the user clicked a delete button and
+nothing happened.
+
+The fix collects every `data-action-*` key from `props` and spreads
+them onto both the anchor and button render branches. The type
+surface gains an index signature so `<Button data-action-tid="…" />`
+type-checks without a per-attribute enumeration.
+
+`tests/browser/ui/primitives.browser.tsx` grows a Button regression
+that plants a `<Button>` with three `data-action-*` extras, installs
+the event delegator, clicks the button, and asserts every extra
+arrived in `ctx.data`. Verified red against the 0.27.1 Button, green
+against the 0.27.2 fix.
+
+#### `mesh-node.js` stripped its `node:fs/promises` imports
+
+The library build compiled every entrypoint under `target: "browser"`,
+which replaced every `import … from "node:fs/promises"` statement in
+`mesh-node.ts` with an empty destructure —
+`var {readFile, rename, writeFile} = (() => ({}))` — turning every
+call on the file-backed keyring storage into a runtime
+`readFile is not a function`. Consumers that reached for
+`@fairfox/polly/mesh/node` — CLI peers, always-on bridges, any
+Node/Bun-side mesh participant — could not load or save a keyring.
+
+`build-lib.ts` now routes `src/mesh-node.ts` through a second
+`Bun.build` pass with `target: "node"`, so the `node:fs/promises`
+and `node:readline/promises` imports survive the bundler. The
+`target: "browser"` pass drops `mesh-node` from its entrypoint list;
+the file was never appropriate for a browser target anyway.
+
 ## [0.27.1] - 2026-04-18
 
 ### Fixed

--- a/build-lib.ts
+++ b/build-lib.ts
@@ -45,7 +45,10 @@ const libResult = await Bun.build({
     // Peer-first and mesh state (isolated subpath exports)
     "src/peer.ts",
     "src/mesh.ts",
-    "src/mesh-node.ts",
+    // mesh-node is built separately with target: "node" below — building
+    // it under target: "browser" replaces its `node:fs/promises` import
+    // with an empty stub (`var {readFile, rename, writeFile} = (() => ({}))`),
+    // which turns every call into a runtime TypeError.
 
     // Elysia integration
     "src/elysia/index.ts",
@@ -111,6 +114,53 @@ if (!libResult.success) {
 }
 
 console.log("✅ Library built");
+console.log("🔨 Building mesh-node (node target, keeps node: imports)...");
+
+// mesh-node has to be built under target: "node" because target: "browser"
+// strips every `node:fs/promises` / `node:readline/promises` import and
+// emits a stub (`var {readFile, rename, writeFile} = (() => ({}))`) that
+// turns every call into a runtime TypeError. The same `external` list
+// keeps peer and optional deps out of the bundle so consumers supply
+// their own WebRTC implementation.
+const meshNodeResult = await Bun.build({
+  entrypoints: ["src/mesh-node.ts"],
+  // Single-entry builds strip the `src/` prefix from the output path
+  // otherwise, so write into `dist/src/` directly to match the
+  // package.json export `./dist/src/mesh-node.js`.
+  outdir: join(DIST_DIR, "src"),
+  target: "node",
+  format: "esm",
+  splitting: false,
+  minify: false,
+  sourcemap: "external",
+  external: [
+    "preact",
+    "@preact/signals",
+    "@automerge/automerge",
+    "@automerge/automerge/automerge.wasm",
+    "@automerge/automerge-repo",
+    "@automerge/automerge-repo/slim",
+    "@automerge/automerge-repo-network-websocket",
+    "@automerge/automerge-repo-storage-indexeddb",
+    "@automerge/automerge-repo-storage-nodefs",
+    "serialize-javascript",
+    "ws",
+    "tweetnacl",
+    "bun",
+    "werift",
+    "@roamhq/wrtc",
+  ],
+});
+
+if (!meshNodeResult.success) {
+  console.error("❌ mesh-node build failed:");
+  for (const log of meshNodeResult.logs) {
+    console.error(log);
+  }
+  process.exit(1);
+}
+
+console.log("✅ mesh-node built");
 console.log("🔨 Building CLI and tools (node target, fully bundled)...");
 
 // Build CLI and tools (node target) - bundle EVERYTHING

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/src/polly-ui/Button.tsx
+++ b/src/polly-ui/Button.tsx
@@ -34,6 +34,12 @@ type BaseButtonProps = {
   label: ComponentChildren;
   "data-action"?: string;
   "aria-label"?: string;
+  /** Additional action-payload attributes the event delegator parses
+   * into `ctx.data`. `data-action-tid="t-17"` becomes `{ tid: "t-17" }`,
+   * `data-action-item-id="…"` becomes `{ itemId: "…" }`, and so on.
+   * Typed as an index signature so every `data-action-*` key the
+   * consumer cares about type-checks without a Button-side enumeration. */
+  [actionDataAttr: `data-action-${string}`]: string | undefined;
 };
 
 type ButtonAsButton = BaseButtonProps & {
@@ -111,6 +117,19 @@ export function Button(props: ButtonProps): JSX.Element {
 
   const dataAction = props["data-action"];
   const ariaLabel = props["aria-label"];
+  // Collect every `data-action-*` extra the consumer passed so the
+  // event delegator can read them off the rendered element. Without
+  // this, anything beyond `data-action` is silently dropped and
+  // handlers fire with an empty `ctx.data`.
+  const actionDataAttrs: Record<string, string> = {};
+  for (const key of Object.keys(props)) {
+    if (key.startsWith("data-action-")) {
+      const value = (props as unknown as Record<string, unknown>)[key];
+      if (typeof value === "string") {
+        actionDataAttrs[key] = value;
+      }
+    }
+  }
 
   if ("href" in props && props.href) {
     return (
@@ -126,6 +145,7 @@ export function Button(props: ButtonProps): JSX.Element {
         data-polly-ui
         data-polly-button={tier}
         data-action={dataAction}
+        {...actionDataAttrs}
       >
         {content}
       </a>
@@ -146,6 +166,7 @@ export function Button(props: ButtonProps): JSX.Element {
       data-polly-ui
       data-polly-button={tier}
       data-action={dataAction}
+      {...actionDataAttrs}
     >
       {content}
     </button>

--- a/tests/browser/ui/primitives.browser.tsx
+++ b/tests/browser/ui/primitives.browser.tsx
@@ -17,7 +17,15 @@ import {
   resetOverlayStack,
   submitError,
 } from "../../../src/actions";
-import { ActionForm, Layout, Modal, OverlayRoot, TextInput, Toast } from "../../../src/polly-ui";
+import {
+  ActionForm,
+  Button,
+  Layout,
+  Modal,
+  OverlayRoot,
+  TextInput,
+  Toast,
+} from "../../../src/polly-ui";
 import {
   cleanup,
   describe,
@@ -279,6 +287,49 @@ describe("TextInput", () => {
     const input = host.querySelector<HTMLInputElement>("input[name=email]")!;
     expect(input.getAttribute("aria-invalid")).toBe("true");
     expect(input.getAttribute("data-state")).toBe("invalid");
+    cleanup(host);
+  });
+});
+
+describe("Button", () => {
+  // Every consumer that uses <Button> to carry additional action data
+  // (data-action-tid, data-action-item-id, etc.) relies on the Button
+  // rendering those attributes on the underlying button element. If
+  // Button silently drops the `data-action-*` extras, clicking the
+  // button fires the handler with an empty `ctx.data` and the handler
+  // typically no-ops on a missing id. The bug is invisible in unit
+  // tests that stub the element directly, so this test plants a real
+  // Button, clicks it, and asserts the event-delegator sees every
+  // attribute the JSX set.
+  test("forwards data-action-* extras to the underlying element", async () => {
+    let received: { action: string; data: Record<string, string> } | undefined;
+    const off = installEventDelegation((d) => {
+      received = { action: d.action, data: d.data };
+    });
+
+    const host = mountHost();
+    render(
+      <Button
+        label="×"
+        tier="tertiary"
+        color="danger"
+        data-action="task.delete"
+        data-action-tid="task-17"
+        data-action-label="Do laundry"
+      />,
+      host
+    );
+    await flush();
+
+    const btn = host.querySelector<HTMLButtonElement>("button[data-action='task.delete']");
+    expect(btn).toExist();
+    btn?.click();
+    await flush();
+
+    expect(received?.action).toBe("task.delete");
+    expect(received?.data).toEqual({ tid: "task-17", label: "Do laundry" });
+
+    off();
     cleanup(host);
   });
 });


### PR DESCRIPTION
Two bugs, both invisible from the happy-path tests, both surfaced by real fairfox consumers doing realistic things with the public API. Each gets a targeted fix and a red-before-green regression test.

## `Button` silently dropped `data-action-*` extras

`<Button>` destructured `data-action` off props and forwarded only that one attribute to the underlying element. Every other `data-action-*` extra — `data-action-tid`, `data-action-item-id`, `data-action-person`, whatever the consumer attached — was accepted by the TS type (the props had no index signature so technically it didn't even type-check, but the JSX catchall let it through) but silently dropped during render. The click bubbled up to the event delegator, the handler fired, `ctx.data` was empty, and guards like `if (!ctx.data.tid) return;` silently no-ed. User clicked a delete button and nothing happened.

**Fix**: the render side collects every `data-action-*` key from props and spreads them onto both the anchor and button branches. The type surface gains an index signature for ``data-action-${string}`` so existing consumer JSX type-checks without a per-attribute enumeration.

**Regression test**: `tests/browser/ui/primitives.browser.tsx` grows a `Button` test that plants a button with three `data-action-*` extras, installs the event delegator, clicks the button, and asserts every attribute arrived on `ctx.data`. Verified red against the 0.27.1 Button, green at HEAD.

## `mesh-node.js` stripped its `node:fs/promises` imports

The library build compiled every entrypoint under `target: "browser"`, which rewrote every `import … from "node:fs/promises"` statement in `mesh-node.ts` to `var {readFile, rename, writeFile} = (() => ({}))`. Every call on `fileKeyringStorage` threw `readFile is not a function` at runtime. Consumers that built CLIs or always-on bridges against `@fairfox/polly/mesh/node` — fairfox's brand-new CLI peer, notably — could not load or save keyrings. fairfox worked around by re-implementing `fileKeyringStorage` locally; once this PR ships it can retire the workaround.

**Fix**: `build-lib.ts` now routes `src/mesh-node.ts` through a second `Bun.build` pass under `target: "node"` and drops `mesh-node` from the browser-target entrypoint list. The `node:fs/promises` and `node:readline/promises` imports survive the bundler, and the runtime call path works.

## Verification

```sh
bun run lint
bun run typecheck
bun run --cwd tests test
bun tools/test/src/browser/run.ts tests/browser
```

640 unit + integration pass. 26 browser tests pass (the `Button` forwarding guard is the one added by this PR). Zero biome warnings. `tsc --noEmit` clean.

Bumped to 0.27.2. Patch because both are bug fixes; the Button type surface only loosens.