### PR TITLE
MeshSignalingClient reconnects on unexpected close (0.27.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.3] - 2026-04-18
+
+### Added
+
+#### `MeshSignalingClient` reconnects on unexpected close
+
+Real deployments hand the signalling server restarts, load-balancer
+rolls, and network blips. Pre-0.27.3 the client noticed the close,
+flipped `joined = false`, called its `onClose` callback, and went
+quiet. Every existing WebRTC data channel survived the drop (they
+are peer-to-peer once open) but no new peer could reach the stranded
+client, and any dropped channel stayed dropped. Users saw "stale
+and disconnected until refresh."
+
+The client now schedules a reconnect on every close that was not
+triggered by an explicit `close()` call. Backoff starts at 250ms and
+doubles up to a 30-second ceiling. Each reconnect reopens the
+WebSocket, re-sends the `join` frame under the same `peerId`, and
+lets the existing `peers-present` / `peer-joined` dispatch replay
+discovery — no caller-side reset, no lost peer ids.
+
+`close()` now sets a `stopping` flag and clears any pending reconnect
+timer, so a consumer that deliberately tears the client down stays
+torn down.
+
+`tests/integration/signaling-client-reconnect.test.ts` is the guard.
+The "re-joins after server restart" test stops the signalling server,
+waits briefly, restarts on the same port, and asserts `onOpen` fires
+a second time with `isConnected` returning true again. The
+"explicit close does not reconnect" test asserts `close()` is
+respected. Verified red against the pre-0.27.3 client (first test
+times out at 10s) and green at HEAD.
+
 ## [0.27.2] - 2026-04-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/src/shared/lib/mesh-signaling-client.ts
+++ b/src/shared/lib/mesh-signaling-client.ts
@@ -72,6 +72,13 @@ export interface MeshSignalingClientOptions {
  * offers, SDP answers, ICE candidates, or any other message the
  * WebRTC adapter wants to exchange with peers.
  */
+/** Base delay (ms) between reconnect attempts. Doubles per attempt up
+ * to {@link RECONNECT_MAX_DELAY_MS}. */
+const RECONNECT_BASE_DELAY_MS = 250;
+/** Ceiling for the exponential backoff so a long outage does not leave
+ * the client silent for minutes between probes. */
+const RECONNECT_MAX_DELAY_MS = 30_000;
+
 export class MeshSignalingClient {
   readonly url: string;
   readonly peerId: string;
@@ -84,6 +91,8 @@ export class MeshSignalingClient {
   private readonly onPeerLeft?: (peerId: string) => void;
   private socket: WebSocket | undefined;
   private joined = false;
+  private stopping = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   private readonly WebSocketCtor: typeof WebSocket;
 
   constructor(options: MeshSignalingClientOptions) {
@@ -111,9 +120,15 @@ export class MeshSignalingClient {
    * promise resolves.
    */
   async connect(): Promise<void> {
+    this.stopping = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
     return new Promise((resolve, reject) => {
       const ws = new this.WebSocketCtor(this.url);
       this.socket = ws;
+      let settled = false;
 
       ws.addEventListener("open", () => {
         // Send the join message as the first frame. The server registers
@@ -122,7 +137,10 @@ export class MeshSignalingClient {
         ws.send(JSON.stringify({ type: "join", peerId: this.peerId } satisfies SignalingMessage));
         this.joined = true;
         this.onOpen?.();
-        resolve();
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
       });
 
       ws.addEventListener("message", (event) => {
@@ -130,14 +148,39 @@ export class MeshSignalingClient {
       });
 
       ws.addEventListener("error", (err) => {
-        reject(err);
+        // Only the initial connect rejects here. Post-open errors route
+        // through the close handler's reconnect path.
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
       });
 
       ws.addEventListener("close", () => {
+        const wasOpen = this.joined;
         this.joined = false;
         this.onClose?.();
+        // If the caller asked to stop, respect it. Otherwise a close on
+        // an established connection — or a close that preempted `open`
+        // — kicks off the reconnect loop.
+        if (!this.stopping && wasOpen) {
+          this.scheduleReconnect(0);
+        }
       });
     });
+  }
+
+  /** Schedule the next reconnect attempt with exponential backoff. */
+  private scheduleReconnect(attempt: number): void {
+    if (this.stopping) return;
+    const delay = Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * 2 ** attempt);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      if (this.stopping) return;
+      void this.connect().catch(() => {
+        this.scheduleReconnect(attempt + 1);
+      });
+    }, delay);
   }
 
   /**
@@ -195,9 +238,16 @@ export class MeshSignalingClient {
 
   /**
    * Close the underlying WebSocket connection. The server's close handler
-   * will evict this peer from its routing table.
+   * will evict this peer from its routing table. Also cancels any
+   * pending reconnect attempt so the client stays closed until the
+   * caller reopens it with another {@link connect} call.
    */
   close(): void {
+    this.stopping = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
     this.socket?.close();
     this.socket = undefined;
     this.joined = false;

--- a/tests/integration/signaling-client-reconnect.test.ts
+++ b/tests/integration/signaling-client-reconnect.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test: MeshSignalingClient recovers from a server drop.
+ *
+ * Real deployments hand the signalling server restarts, network blips,
+ * and load-balancer rolls. A production client that opens a WebSocket,
+ * sends its join frame, and then lets the connection silently die on
+ * server close is not something a user can tell apart from "the whole
+ * thing broke." This test spins up the Elysia signalling plugin on a
+ * fixed port, connects a MeshSignalingClient, stops the server, brings
+ * it back up on the same port, and asserts the client has re-joined
+ * without any intervention from the caller — the onOpen callback fires
+ * twice and `isConnected` returns true again.
+ *
+ * Red against a MeshSignalingClient that only logs the close; green
+ * once the client schedules a reconnect on every non-stopping close.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { signalingServer } from "@/elysia/signaling-server-plugin";
+import { MeshSignalingClient } from "@/shared/lib/mesh-signaling-client";
+
+interface RunningApp {
+  stop: () => Promise<void>;
+}
+
+let pendingApps: Array<RunningApp> = [];
+
+afterEach(async () => {
+  for (const app of pendingApps) {
+    try {
+      await app.stop();
+    } catch {
+      // best effort
+    }
+  }
+  pendingApps = [];
+}, 10000);
+
+function startSignaling(port: number): RunningApp {
+  const app = new Elysia().use(signalingServer({ path: "/polly/signaling" })).listen(port);
+  const handle: RunningApp = {
+    stop: async () => {
+      (app as unknown as { server?: { stop?: (force?: boolean) => void } }).server?.stop?.(true);
+      // Give the OS a tick to release the port before the next listen().
+      await new Promise((r) => setTimeout(r, 100));
+    },
+  };
+  pendingApps.push(handle);
+  return handle;
+}
+
+function pickPort(): number {
+  return 30000 + Math.floor(Math.random() * 10000);
+}
+
+describe("MeshSignalingClient reconnect", () => {
+  test("re-joins automatically after the server restarts on the same port", async () => {
+    const port = pickPort();
+    let app = startSignaling(port);
+    const url = `ws://127.0.0.1:${port}/polly/signaling`;
+
+    let openCount = 0;
+    const client = new MeshSignalingClient({
+      url,
+      peerId: "peer-reconnect",
+      onSignal: () => {},
+      onOpen: () => {
+        openCount += 1;
+      },
+    });
+
+    await client.connect();
+    expect(openCount).toBe(1);
+    expect(client.isConnected).toBe(true);
+
+    // Server drops: restart on the same port after a brief gap.
+    await app.stop();
+    await new Promise((r) => setTimeout(r, 200));
+    app = startSignaling(port);
+
+    // Wait for the client to reconnect on its own. The exponential
+    // backoff starts at 250ms, so a second onOpen call should land
+    // inside a few seconds.
+    const deadline = Date.now() + 10000;
+    while (Date.now() < deadline) {
+      if (openCount >= 2 && client.isConnected) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    expect(openCount).toBeGreaterThanOrEqual(2);
+    expect(client.isConnected).toBe(true);
+
+    client.close();
+  }, 20000);
+
+  test("does not reconnect after an explicit close()", async () => {
+    const port = pickPort();
+    startSignaling(port);
+    const url = `ws://127.0.0.1:${port}/polly/signaling`;
+
+    let openCount = 0;
+    const client = new MeshSignalingClient({
+      url,
+      peerId: "peer-explicit-close",
+      onSignal: () => {},
+      onOpen: () => {
+        openCount += 1;
+      },
+    });
+
+    await client.connect();
+    expect(openCount).toBe(1);
+
+    client.close();
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // A reconnect would have produced a second onOpen by now.
+    expect(openCount).toBe(1);
+    expect(client.isConnected).toBe(false);
+  }, 10000);
+});


### PR DESCRIPTION
## Why

Real deployments hand the signalling server restarts, load-balancer rolls, and network blips. Pre-0.27.3 the client noticed the close, flipped `joined=false`, called its `onClose` callback, and went quiet. Every existing WebRTC data channel survived the drop — they are peer-to-peer once open — but no new peer could reach the stranded client, and any dropped channel stayed dropped. Users saw "stale and disconnected until I refresh the page."

Observed against fairfox: Railway deploys cycle the server every release, and every open tab had to be manually reloaded before discovery would work again.

## The fix

The client now schedules a reconnect on every close that was not triggered by an explicit `close()` call. Backoff starts at 250ms and doubles up to a 30-second ceiling. Each reconnect reopens the WebSocket, re-sends the `join` frame under the same `peerId`, and lets the existing `peers-present` / `peer-joined` dispatch replay discovery.

First-attempt connect failures still reject the returned promise — only closes on an established connection trigger the reconnect loop, so application-level error handling for bad URLs is unchanged.

`close()` now sets a `stopping` flag and clears any pending reconnect timer, so a consumer that deliberately tears the client down stays torn down.

## Regression test

`tests/integration/signaling-client-reconnect.test.ts` has two cases:

- *re-joins after server restart* — starts the signalling server, connects the client, stops the server, restarts on the same port, asserts `onOpen` fires a second time and `isConnected` returns true.
- *explicit close does not reconnect* — asserts `close()` halts the loop.

Verified red against the pre-0.27.3 client (first test times out at 10s) and green at HEAD.

## Version

Patch. Additive behaviour that existing consumers inherit for free. No API surface change beyond the `stopping`-flag semantics on `close()`.