### PR TITLE
Lift the raw-HTML-element ban into @fairfox/polly/quality (0.27.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.4] - 2026-04-18
+
+### Added
+
+#### `checkSharedComponents` quality check
+
+`@fairfox/polly/quality` now exports a programmatic check that scans
+a directory for raw native HTML elements that have a polly primitive
+equivalent — `<button>` → `<Button>`, `<input>` → `<ActionInput>` /
+`<TextInput>`, `<textarea>` → `<ActionInput variant="multi">`,
+`<select>` → `<Select>`, `<form>` → `<ActionForm>`, `<dialog>` →
+`<Modal>`. Consumers wire it into their own `bun check` script and
+pass `exemptPackages` / `additionalRules` for legacy code or
+application-specific extensions.
+
+The check was lifted from fairfox's `scripts/check-shared-components.ts`
+and generalised — it takes a `root` + optional `scanRoot`, and
+returns a `{ violations, print() }` result. The printing path is
+injectable so consumers can route output through their own logger.
+Default rules add `<dialog>` on top of the fairfox originals now
+that `<Modal>` is the published replacement; `<input type="hidden">`
+gets a `skip` predicate because hidden inputs have no primitive
+analogue.
+
+`tests/unit/quality/check-shared-components.test.ts` covers every
+default rule, the hidden-input skip, the exempt-package escape
+hatch, a consumer-supplied `additionalRules` entry, commented-out
+elements being ignored, the default skip-dirs traversal, and the
+`print()` log-sink injection.
+
 ## [0.27.3] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/tests/unit/quality/check-shared-components.test.ts
+++ b/tests/unit/quality/check-shared-components.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit test for @fairfox/polly/quality's checkSharedComponents.
+ *
+ * Builds a fake package tree in a tmp directory, plants .tsx files
+ * with raw HTML elements that should be banned (and a few that should
+ * not), runs the check, and asserts the violation list.
+ *
+ * Covers:
+ *   - every element in the default rule set (<button>, <input>,
+ *     <textarea>, <select>, <form>, <dialog>)
+ *   - the <input type="hidden"> skip predicate
+ *   - the "exempt packages" escape hatch
+ *   - a consumer-supplied `additionalRules` entry
+ *   - commented-out elements being ignored
+ */
+
+import { beforeEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkSharedComponents } from "@fairfox/polly/quality";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "polly-shared-components-"));
+});
+
+async function plant(relPath: string, text: string): Promise<void> {
+  const abs = join(root, relPath);
+  await mkdir(join(abs, ".."), { recursive: true });
+  await writeFile(abs, text);
+}
+
+test("flags every default-rule element", async () => {
+  await plant(
+    "packages/app/src/App.tsx",
+    `
+    export function App() {
+      return (
+        <div>
+          <button>Click</button>
+          <input type="text" />
+          <textarea />
+          <select />
+          <form action="/x" />
+          <dialog open />
+        </div>
+      );
+    }
+    `.trim()
+  );
+  const result = await checkSharedComponents({ root });
+  const elements = result.violations.map((v) => v.element).sort();
+  expect(elements).toEqual(["<button>", "<dialog>", "<form>", "<input>", "<select>", "<textarea>"]);
+});
+
+test("skips <input type='hidden'>", async () => {
+  await plant(
+    "packages/app/src/App.tsx",
+    `
+    export function App() {
+      return <input type="hidden" value="csrf" />;
+    }
+    `.trim()
+  );
+  const result = await checkSharedComponents({ root });
+  expect(result.violations).toEqual([]);
+});
+
+test("exempts named packages", async () => {
+  await plant("packages/legacy/src/Legacy.tsx", `export const X = () => <button />;`);
+  await plant("packages/fresh/src/Fresh.tsx", `export const Y = () => <button />;`);
+  const result = await checkSharedComponents({
+    root,
+    exemptPackages: new Set(["legacy"]),
+  });
+  expect(result.violations.map((v) => v.file)).toEqual(["packages/fresh/src/Fresh.tsx"]);
+});
+
+test("accepts additional consumer rules", async () => {
+  await plant(
+    "packages/app/src/App.tsx",
+    `
+    export const X = () => <marquee>scroll</marquee>;
+    `.trim()
+  );
+  const result = await checkSharedComponents({
+    root,
+    additionalRules: [
+      { pattern: /<marquee[\s>]/, element: "<marquee>", replacement: "<ScrollingText>" },
+    ],
+  });
+  expect(result.violations).toHaveLength(1);
+  expect(result.violations[0]?.element).toBe("<marquee>");
+});
+
+test("ignores commented-out elements", async () => {
+  await plant(
+    "packages/app/src/App.tsx",
+    `
+    export function App() {
+      // <button>old</button>
+      return null;
+    }
+    `.trim()
+  );
+  const result = await checkSharedComponents({ root });
+  expect(result.violations).toEqual([]);
+});
+
+test("skips dotted dirs in the traversal default", async () => {
+  await plant("packages/app/dist/build.tsx", `export const X = () => <button />;`);
+  await plant("packages/app/node_modules/foo.tsx", `export const X = () => <button />;`);
+  await plant("packages/app/src/App.tsx", `export const X = () => <div>ok</div>;`);
+  const result = await checkSharedComponents({ root });
+  expect(result.violations).toEqual([]);
+});
+
+test("print() summarises violations through the supplied log sink", async () => {
+  await plant("packages/app/src/App.tsx", `export const X = () => <button />;`);
+  const result = await checkSharedComponents({ root });
+  const captured: string[] = [];
+  result.print((m) => captured.push(m));
+  expect(captured.some((line) => line.includes("1 violation(s)"))).toBe(true);
+  expect(captured.some((line) => line.includes("<button>"))).toBe(true);
+});

--- a/tools/quality/src/check-shared-components.ts
+++ b/tools/quality/src/check-shared-components.ts
@@ -1,0 +1,222 @@
+/**
+ * Ban raw native interactive HTML elements in app source.
+ *
+ * Applications that consume `@fairfox/polly/ui` are expected to use
+ * the shared primitives (`<Button>`, `<ActionInput>`, `<Layout>`,
+ * `<Modal>`, `<ActionForm>`, `<Select>`) rather than writing raw
+ * `<button>`, `<input>`, `<select>`, `<textarea>`, `<form>`, or
+ * `<dialog>` elements. The primitives enforce data-action delegation,
+ * typed CSS-module classNames, accessibility attributes, and the
+ * layouting ban.
+ *
+ * This module exposes a programmatic check — `checkSharedComponents`
+ * — that walks a directory, scans every .tsx / .jsx file, and
+ * returns every violation it finds. Consumers typically wire it into
+ * a `bun check` script and set `exemptPackages` / `allowPaths` for
+ * legacy code that can't migrate yet.
+ *
+ * @example
+ * ```ts
+ * import { checkSharedComponents } from "@fairfox/polly/quality";
+ *
+ * const result = await checkSharedComponents({
+ *   root: process.cwd(),
+ *   scanRoot: "packages",
+ *   exemptPackages: new Set(["struggle", "todo"]),
+ * });
+ * if (result.violations.length > 0) {
+ *   result.print(console.error);
+ *   process.exit(1);
+ * }
+ * ```
+ */
+
+import type { Dirent } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+/** One raw-element rule. Each rule flags a native element and
+ * suggests the polly primitive that replaces it. */
+export interface SharedComponentRule {
+  /** Regular expression that matches the opening tag, e.g. /<button[\s>]/. */
+  pattern: RegExp;
+  /** Human-readable element marker, e.g. "<button>". */
+  element: string;
+  /** Suggested replacement, e.g. "<Button>". */
+  replacement: string;
+  /** Optional predicate; when it returns true the match is skipped.
+   * Used for legitimate raw usages (e.g. `<input type="hidden">`)
+   * that have no primitive analogue. */
+  skip?: (line: string) => boolean;
+}
+
+/** Default rule set. Covers every native element that has a
+ * direct `@fairfox/polly/ui` replacement. Consumers may extend
+ * through the `additionalRules` option. */
+export const DEFAULT_SHARED_COMPONENT_RULES: SharedComponentRule[] = [
+  { pattern: /<button[\s>]/, element: "<button>", replacement: "<Button>" },
+  {
+    pattern: /<input[\s>/]/,
+    element: "<input>",
+    replacement: "<ActionInput> or <TextInput>",
+    // `<input type="hidden">` has no primitive analogue and is a
+    // legitimate way to carry form data.
+    skip: (line) => /type=["']hidden["']/.test(line),
+  },
+  {
+    pattern: /<textarea[\s>]/,
+    element: "<textarea>",
+    replacement: '<ActionInput variant="multi">',
+  },
+  { pattern: /<select[\s>]/, element: "<select>", replacement: "<Select>" },
+  { pattern: /<form[\s>]/, element: "<form>", replacement: "<ActionForm>" },
+  { pattern: /<dialog[\s>]/, element: "<dialog>", replacement: "<Modal>" },
+];
+
+/** One violation: a raw element found in an app source file. */
+export interface SharedComponentViolation {
+  /** Path relative to `root`. */
+  file: string;
+  /** 1-based line number. */
+  line: number;
+  /** Element marker, e.g. "<button>". */
+  element: string;
+  /** Suggested replacement. */
+  replacement: string;
+  /** Trimmed offending line for context. */
+  content: string;
+}
+
+export interface CheckSharedComponentsOptions {
+  /** Repository root. Violation file paths are reported relative to
+   * this directory. */
+  root: string;
+  /** Directory under `root` to scan. Defaults to "packages". */
+  scanRoot?: string;
+  /** Directory names to skip entirely during traversal. Defaults to
+   * node_modules / .git / dist / build / tests. */
+  skipDirs?: Set<string>;
+  /** Workspace package names (the directory names immediately under
+   * `scanRoot`) to exempt. Useful for legacy packages that can't
+   * migrate to the primitives yet. */
+  exemptPackages?: Set<string>;
+  /** Additional rules appended to {@link DEFAULT_SHARED_COMPONENT_RULES}. */
+  additionalRules?: SharedComponentRule[];
+  /** Override the default rule set entirely. If set,
+   * `additionalRules` is ignored. */
+  rules?: SharedComponentRule[];
+}
+
+const DEFAULT_SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", "tests"]);
+
+export interface SharedComponentsCheckResult {
+  violations: SharedComponentViolation[];
+  print(log: (msg: string) => void): void;
+}
+
+/** Walk the configured directory, returning every violation found. */
+export async function checkSharedComponents(
+  options: CheckSharedComponentsOptions
+): Promise<SharedComponentsCheckResult> {
+  const rules = options.rules ?? [
+    ...DEFAULT_SHARED_COMPONENT_RULES,
+    ...(options.additionalRules ?? []),
+  ];
+  const skipDirs = options.skipDirs ?? DEFAULT_SKIP_DIRS;
+  const scanRoot = options.scanRoot ?? "packages";
+  const exemptPackages = options.exemptPackages ?? new Set<string>();
+  const packagesPath = join(options.root, scanRoot);
+  const violations: SharedComponentViolation[] = [];
+
+  await scanDirectory(packagesPath, {
+    root: options.root,
+    packagesPath,
+    skipDirs,
+    exemptPackages,
+    rules,
+    violations,
+  });
+
+  return {
+    violations,
+    print(log) {
+      if (violations.length === 0) {
+        log("[shared-components] ok");
+        return;
+      }
+      log(`[shared-components] ${violations.length} violation(s) found:\n`);
+      for (const v of violations) {
+        log(`  ${v.file}:${v.line} — ${v.element} → use ${v.replacement}`);
+        log(`    ${v.content}\n`);
+      }
+      log("[shared-components] Use @fairfox/polly/ui primitives instead of native HTML elements.");
+    },
+  };
+}
+
+interface ScanState {
+  root: string;
+  packagesPath: string;
+  skipDirs: Set<string>;
+  exemptPackages: Set<string>;
+  rules: SharedComponentRule[];
+  violations: SharedComponentViolation[];
+}
+
+async function scanDirectory(dir: string, state: ScanState): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (state.skipDirs.has(entry.name)) {
+        continue;
+      }
+      if (dir === state.packagesPath && state.exemptPackages.has(entry.name)) {
+        continue;
+      }
+      await scanDirectory(fullPath, state);
+    } else if (entry.isFile() && (entry.name.endsWith(".tsx") || entry.name.endsWith(".jsx"))) {
+      await scanFile(fullPath, state);
+    }
+  }
+}
+
+async function scanFile(filePath: string, state: ScanState): Promise<void> {
+  const text = await Bun.file(filePath).text();
+  const lines = text.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    const trimmed = line.trim();
+    if (isCommentLine(trimmed)) continue;
+    for (const rule of state.rules) {
+      if (!matchesRule(line, rule)) continue;
+      state.violations.push({
+        file: relative(state.root, filePath),
+        line: i + 1,
+        element: rule.element,
+        replacement: rule.replacement,
+        content: trimmed,
+      });
+    }
+  }
+}
+
+function isCommentLine(trimmed: string): boolean {
+  return trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*");
+}
+
+function matchesRule(line: string, rule: SharedComponentRule): boolean {
+  if (!rule.pattern.test(line)) return false;
+  const commentIndex = line.indexOf("//");
+  const elementIndex = line.search(rule.pattern);
+  if (commentIndex !== -1 && commentIndex < elementIndex) return false;
+  if (rule.skip?.(line)) return false;
+  return true;
+}

--- a/tools/quality/src/index.ts
+++ b/tools/quality/src/index.ts
@@ -30,10 +30,17 @@
  */
 
 export {
+  type CheckSharedComponentsOptions,
+  checkSharedComponents,
+  DEFAULT_SHARED_COMPONENT_RULES,
+  type SharedComponentRule,
+  type SharedComponentsCheckResult,
+  type SharedComponentViolation,
+} from "./check-shared-components.ts";
+export {
   type CssLayoutOptions,
   checkCssLayout,
 } from "./css/check-layout.ts";
-
 export {
   type CssQualityOptions,
   checkCssQuality,


### PR DESCRIPTION
Applications that consume `@fairfox/polly/ui` are expected to use the shared primitives rather than raw `<button>`, `<input>`, `<textarea>`, `<select>`, `<form>`, or `<dialog>`. Fairfox runs its own `scripts/check-shared-components.ts` to enforce this; any other polly consumer that wants the rule has to copy the script. This PR moves the check into polly's quality tool surface so it ships from one place.

## What's new

- `@fairfox/polly/quality` exports `checkSharedComponents(options)` and the companion types. Options cover `root`, `scanRoot`, `skipDirs`, `exemptPackages`, `additionalRules`, and a full `rules` override. The result has a `violations` list and a `print(log)` helper whose sink is injectable.
- Default rule set covers the six elements above. `<dialog>` is new relative to the fairfox original (previously the Modal primitive hadn't shipped). `<input type="hidden">` gets a `skip` predicate because hidden inputs have no polly replacement and are a legitimate way to carry form data.

## Regression test

`tests/unit/quality/check-shared-components.test.ts` covers every default rule in a single planted-package test, plus the hidden-input skip, the exempt-package escape hatch, consumer-supplied `additionalRules`, commented-out elements, the default skip-dirs traversal, and the `print()` log-sink. 7/7 green.

## Version

0.27.4. Patch because the API is purely additive — the new export sits alongside the existing CSS checks and `checkNoAsCasting`.

## After this ships

Fairfox replaces its local `scripts/check-shared-components.ts` with a thin wrapper that calls `checkSharedComponents({ root, exemptPackages: new Set(["struggle", "todo"]) })`. Separate PR once 0.27.4 is on npm.