### PR TITLE
fileKeyringStorage creates its parent directory (0.27.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.5] - 2026-04-18
+
+### Fixed
+
+#### `fileKeyringStorage` mkdirs its parent directory before the first write
+
+First-run on a fresh machine typically points `fileKeyringStorage`
+at a path whose parent hasn't been created yet — `~/.fairfox/keyring.json`
+is the canonical shape. The previous implementation went straight to
+`writeFile` on a `${path}.tmp-*` sibling, which failed at `open()` with
+`ENOENT` when the parent was missing and aborted the pairing bootstrap.
+
+`save` now calls `mkdir(dirname(path), { recursive: true })` before the
+write-to-tmp-then-rename dance. The `load` path is unchanged — a
+missing file still returns `null`.
+
+A new unit test (`save creates the parent directory when it does not exist`)
+pins this to a nested path under a fresh `tmpdir` and asserts the
+keyring round-trips.
+
 ## [0.27.4] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/src/mesh-node.ts
+++ b/src/mesh-node.ts
@@ -38,7 +38,8 @@
  * ```
  */
 
-import { readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { createInterface } from "node:readline/promises";
 import {
   deserialiseKeyring,
@@ -77,6 +78,11 @@ export function fileKeyringStorage(path: string): KeyringStorage {
       }
     },
     save: async (keyring) => {
+      // First-run on a fresh machine often points this storage at a
+      // path whose parent directory hasn't been created yet (the
+      // typical `~/.fairfox/keyring.json` shape). mkdir -p the parent
+      // up front so the write-to-tmp step doesn't fail at open().
+      await mkdir(dirname(path), { recursive: true });
       const text = serialiseKeyring(keyring);
       const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
       await writeFile(tmp, text, { mode: 0o600 });

--- a/tests/unit/mesh-node.test.ts
+++ b/tests/unit/mesh-node.test.ts
@@ -57,6 +57,24 @@ describe("fileKeyringStorage", () => {
     expect(entries.some((e) => e.endsWith(".tmp"))).toBe(false);
     expect(entries).toContain("keyring.json");
   });
+
+  test("save creates the parent directory when it does not exist", async () => {
+    // First-run on a fresh machine: the consumer points
+    // fileKeyringStorage at ~/.fairfox/keyring.json and the parent
+    // hasn't been created yet. The save should mkdir -p rather than
+    // fail at open() on the tmp path.
+    const dir = tmpDir();
+    const nested = join(dir, "profile", "fairfox", "keyring.json");
+    const storage = fileKeyringStorage(nested);
+    await storage.save({
+      identity: generateSigningKeyPair(),
+      knownPeers: new Map(),
+      documentKeys: new Map([["polly-mesh-default", new Uint8Array(32)]]),
+      revokedPeers: new Set(),
+    });
+    const reloaded = await storage.load();
+    expect(reloaded).not.toBeNull();
+  });
 });
 
 describe("bootstrapCliKeyring", () => {


### PR DESCRIPTION
## Summary

`fileKeyringStorage.save` now runs `mkdir(dirname(path), { recursive: true })` before the write-to-tmp-then-rename dance, so first-run on a fresh machine no longer fails at `open()` with ENOENT when the parent directory hasn't been created yet (canonically `~/.fairfox/keyring.json`).

The `load` path is unchanged — a missing file still returns `null`.

Unblocks CLI peers that persist their keyring under a nested dotfile directory without the consumer having to `mkdir -p` in a wrapper first.

## Changes

- `src/mesh-node.ts` — `save` mkdirs `dirname(path)` recursively; added imports for `mkdir` and `node:path/dirname`.
- `tests/unit/mesh-node.test.ts` — red-before-green test `save creates the parent directory when it does not exist`. Round-trips a keyring under a nested tmpdir path.
- `CHANGELOG.md` — 0.27.5 entry.
- `package.json` — version bump to 0.27.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)