### PR TITLE
feat: mesh sync-state runtime overlay for the visualiser

### DIFF
--- a/packages/polly/scripts/e2e-visualize.ts
+++ b/packages/polly/scripts/e2e-visualize.ts
@@ -8,13 +8,15 @@
 // docs/architecture.dsl contains pinned context and component
 // identifiers.
 //
-// Scope: --generate only. --export wraps Docker and warrants its own
-// script.
+// Scope: `generate`, with and without `--snapshot`. `--export` wraps
+// Docker and warrants its own script.
 //
 // Examples covered:
 //   minimal           — single-package extension, runs at example root
 //   elysia-todo-app   — workspace, runs from server/
 //   webrtc-p2p-chat   — workspace, runs from server/
+//   mesh-overlay      — polly#127: `generate --snapshot` overlays a
+//                       captured MeshClientPeerStateSnapshot
 //
 // On failure the tmp dir is retained and printed so the generated DSL
 // can be inspected in place. On success the tmp dir is removed.
@@ -51,6 +53,10 @@ type Case = {
   minComponents: number;
   expectedExternalSystems?: string[];
   minRelationships?: number;
+  /** polly#127: snapshot file (relative to the run cwd) passed via
+   * `generate --snapshot`. When set, the DSL is checked for the runtime
+   * mesh overlay. */
+  snapshot?: string;
 };
 
 type Result = {
@@ -114,6 +120,19 @@ const cases: Case[] = [
     ],
     minComponents: 9,
   },
+  {
+    // polly#127: the mesh-app fixture declares two $meshState documents;
+    // its committed snapshot.json overlays runtime peers and
+    // sync-state-coloured edges onto them through the real CLI.
+    label: "mesh-overlay",
+    examplePath: "packages/polly/tools/visualize/src/__tests__/fixtures/mesh-app",
+    cwdSubpath: "",
+    expectedWorkspace: "test-mesh-app",
+    expectedContainers: ["server", "mesh_doc_chat_rooms", "mesh_doc_chat_presence"],
+    expectedComponents: [],
+    minComponents: 0,
+    snapshot: "snapshot.json",
+  },
 ];
 
 let dockerProbe: Promise<boolean> | null = null;
@@ -176,7 +195,8 @@ async function runOne(c: Case): Promise<Result> {
 
   const cwd = c.cwdSubpath ? path.join(exampleCopy, c.cwdSubpath) : exampleCopy;
 
-  const proc = Bun.spawn(["bun", POLLY_CLI, "visualize"], {
+  const cliArgs = c.snapshot ? ["visualize", "generate", "--snapshot", c.snapshot] : ["visualize"];
+  const proc = Bun.spawn(["bun", POLLY_CLI, ...cliArgs], {
     cwd,
     stdout: "pipe",
     stderr: "pipe",
@@ -280,6 +300,38 @@ function checkDsl(c: Case, dsl: string): string[] {
     if (relCount < c.minRelationships) {
       failures.push(`expected ≥${c.minRelationships} relationships, got ${relCount}`);
     }
+  }
+
+  if (c.snapshot) failures.push(...checkOverlay(dsl));
+
+  return failures;
+}
+
+/**
+ * polly#127: assert the runtime mesh overlay reached the DSL — a peer
+ * `person` node, status-coloured edges into the static mesh documents,
+ * a snapshot-only node, and the `sync:*` relationship styles.
+ */
+function checkOverlay(dsl: string): string[] {
+  const failures: string[] = [];
+
+  if (!dsl.includes('person "peer-aa11"')) {
+    failures.push("overlay peer node peer-aa11 not found");
+  }
+  if (!dsl.includes('tags "Local Mesh Peer"')) {
+    failures.push("local peer is not tagged");
+  }
+  for (const tag of ["sync:has", "sync:wants", "sync:unavailable", "sync:unknown"]) {
+    if (!dsl.includes(`tags "${tag}"`)) failures.push(`overlay edge tag ${tag} not found`);
+    if (!dsl.includes(`relationship "${tag}"`)) {
+      failures.push(`overlay relationship style ${tag} not found`);
+    }
+  }
+  if (!/->\s*extension\.mesh_doc_chat_rooms\b/.test(dsl)) {
+    failures.push("overlay edge into mesh_doc_chat_rooms not found");
+  }
+  if (!dsl.includes('tags "Snapshot Document"')) {
+    failures.push("snapshot-only document node not found");
   }
 
   return failures;

--- a/packages/polly/src/shared/lib/derive-document-id.ts
+++ b/packages/polly/src/shared/lib/derive-document-id.ts
@@ -1,0 +1,38 @@
+/**
+ * Leaf module for {@link deriveDocumentId}. Kept free of the wider
+ * `mesh-state` module graph (CRDT primitives, the Repo, schema
+ * migrations) so that tooling — notably `polly visualize` (polly#127) —
+ * can resolve a logical key to its {@link DocumentId} without pulling
+ * the whole mesh runtime into its bundle. `mesh-state` re-exports it,
+ * so consumer-facing imports are unchanged.
+ */
+
+import {
+  type BinaryDocumentId,
+  type DocumentId,
+  interpretAsDocumentId,
+} from "@automerge/automerge-repo/slim";
+import nacl from "tweetnacl";
+
+/** Domain prefix pinning the derivation to $meshState so that the same
+ * logical key used in a different Polly subsystem would produce a
+ * different id. */
+const DOC_ID_DOMAIN = "polly/meshState/v1";
+const keyEncoder = new TextEncoder();
+
+/**
+ * Domain-separated hash of an application key into a 16-byte
+ * {@link DocumentId}. SHA-512 via tweetnacl (already a dep for
+ * signing); the first 16 bytes give a DocumentId with uniform
+ * distribution across the Automerge id space.
+ *
+ * Exported so consumers can compute the derived id for any logical key
+ * — useful for ADR 0008-style document compaction where the consumer
+ * wants to seed a new doc at `deriveDocumentId(key + ':v' + timestamp)`
+ * and stash that id in a runtime index.
+ */
+export function deriveDocumentId(key: string): DocumentId {
+  const digest = nacl.hash(keyEncoder.encode(`${DOC_ID_DOMAIN}:${key}`));
+  const bytes = digest.slice(0, 16);
+  return interpretAsDocumentId(bytes as unknown as BinaryDocumentId);
+}

--- a/packages/polly/src/shared/lib/mesh-state.ts
+++ b/packages/polly/src/shared/lib/mesh-state.ts
@@ -40,10 +40,8 @@
 
 import {
   Automerge,
-  type BinaryDocumentId,
   type DocHandle,
   type DocumentId,
-  interpretAsDocumentId,
   type Repo,
 } from "@automerge/automerge-repo/slim";
 import nacl from "tweetnacl";
@@ -58,6 +56,7 @@ import {
   type TextDoc,
 } from "./crdt-specialised";
 import { $crdtState, type CrdtPrimitive } from "./crdt-state";
+import { deriveDocumentId } from "./derive-document-id";
 import type { Migrations, VersionedDoc } from "./schema-version";
 
 /** Common option shape across all four $mesh* primitives. */
@@ -502,29 +501,17 @@ function resolveRepo(option: Repo | undefined): Repo {
   return repo;
 }
 
-/**
- * Domain-separated hash of an application key into a 16-byte
- * {@link BinaryDocumentId}. SHA-512 via tweetnacl (already a dep for signing);
- * the first 16 bytes give a DocumentId with uniform distribution across the
- * Automerge id space. The domain prefix pins the derivation to $meshState so
- * that the same logical key used in a different Polly subsystem would
- * produce a different id.
- */
-const DOC_ID_DOMAIN = "polly/meshState/v1";
+/** Shared text encoder for the domain-separated key hashes in this
+ * module (the seed-actor derivation below). */
 const keyEncoder = new TextEncoder();
 
 /**
  * Domain-separated hash of an application key into a 16-byte
- * {@link DocumentId}. Exported so consumers can compute the
- * derived id for any logical key — useful for ADR 0008-style
- * document compaction where the consumer wants to seed a new doc
- * at `deriveDocumentId(key + ':v' + timestamp)` and stash that id
- * in a runtime index. */
-export function deriveDocumentId(key: string): DocumentId {
-  const digest = nacl.hash(keyEncoder.encode(`${DOC_ID_DOMAIN}:${key}`));
-  const bytes = digest.slice(0, 16);
-  return interpretAsDocumentId(bytes as unknown as BinaryDocumentId);
-}
+ * {@link DocumentId}. Lives in the {@link ./derive-document-id} leaf
+ * module so tooling can resolve a key without the mesh runtime;
+ * re-exported here to keep `@fairfox/polly/mesh` imports unchanged.
+ */
+export { deriveDocumentId };
 
 /**
  * Caller-installed resolver consulted at every `$mesh*` wrapper
@@ -725,8 +712,8 @@ function buildHandleFactory<D>(
  * ones and the top-level fields anchor to a single map. Subsequent per-key
  * writes use the peer's own random actor and merge cleanly.
  *
- * The domain prefix is separate from {@link DOC_ID_DOMAIN} so the seed-actor
- * derivation cannot collide with the docId derivation even if a future
+ * The domain prefix is separate from the docId derivation's prefix so
+ * the seed-actor derivation cannot collide with it even if a future
  * change reuses one of the byte ranges. */
 const SEED_ACTOR_DOMAIN = "polly/meshState/seedActor/v1";
 

--- a/packages/polly/tools/visualize/src/__tests__/fixtures/mesh-app/snapshot.json
+++ b/packages/polly/tools/visualize/src/__tests__/fixtures/mesh-app/snapshot.json
@@ -1,0 +1,127 @@
+{
+  "localPeerId": "peer-local-7c1d",
+  "knownPeerIds": ["peer-aa11", "peer-bb22", "peer-cc33"],
+  "presentPeerIds": ["peer-aa11", "peer-bb22"],
+  "sweep": {
+    "enabled": true,
+    "intervalMs": 15000,
+    "runCount": 12,
+    "lastRunAt": 184320.5
+  },
+  "peers": [
+    {
+      "peerId": "peer-aa11",
+      "knownInKeyring": true,
+      "presentInSignalling": true,
+      "slotInitiationDecision": {
+        "decision": "accepted",
+        "at": 184100.2
+      },
+      "slot": {
+        "signalingState": "stable",
+        "iceConnectionState": "connected",
+        "connectionState": "connected",
+        "dataChannelState": "open",
+        "pendingSendCount": 0,
+        "pendingRemoteIceCount": 0,
+        "lastSyncHandshakeAttempt": {
+          "dataChannelOpenedAt": 184010.0,
+          "peerCandidateEmittedAt": 184011.0,
+          "firstOutboundSendAt": 184012.0,
+          "firstInboundMessageAt": 184013.0
+        },
+        "createdAt": 184000.0,
+        "lastInboundAt": 184300.0,
+        "handles": {
+          "f7sSXAhTsVrbgbbMtQYATUVQbRy": {
+            "state": "ready",
+            "announcedToPeer": true,
+            "lastSyncMessageOutAt": 184200.0,
+            "lastSyncMessageInAt": 184250.0,
+            "lastSyncMessageOutSize": 512,
+            "lastSyncMessageOutType": "sync",
+            "docSynchronizerExists": true,
+            "docSynchronizerKnowsPeer": true,
+            "peerDocumentStatus": "has"
+          },
+          "2TWmaxBiQmvJtCrtQ6PTj4NX5eVE": {
+            "state": "ready",
+            "announcedToPeer": true,
+            "lastSyncMessageOutAt": 184210.0,
+            "lastSyncMessageInAt": 184220.0,
+            "lastSyncMessageOutSize": 96,
+            "lastSyncMessageOutType": "sync",
+            "docSynchronizerExists": true,
+            "docSynchronizerKnowsPeer": true,
+            "peerDocumentStatus": "wants"
+          }
+        }
+      }
+    },
+    {
+      "peerId": "peer-bb22",
+      "knownInKeyring": true,
+      "presentInSignalling": true,
+      "slotInitiationDecision": {
+        "decision": "accepted",
+        "at": 184105.7
+      },
+      "slot": {
+        "signalingState": "stable",
+        "iceConnectionState": "connected",
+        "connectionState": "connected",
+        "dataChannelState": "open",
+        "pendingSendCount": 1,
+        "pendingRemoteIceCount": 0,
+        "lastSyncHandshakeAttempt": {
+          "dataChannelOpenedAt": 184020.0,
+          "peerCandidateEmittedAt": 184021.0,
+          "firstOutboundSendAt": 184022.0
+        },
+        "createdAt": 184005.0,
+        "lastInboundAt": 184260.0,
+        "handles": {
+          "f7sSXAhTsVrbgbbMtQYATUVQbRy": {
+            "state": "ready",
+            "announcedToPeer": true,
+            "lastSyncMessageOutAt": 184230.0,
+            "lastSyncMessageOutSize": 512,
+            "lastSyncMessageOutType": "request",
+            "docSynchronizerExists": true,
+            "docSynchronizerKnowsPeer": false,
+            "peerDocumentStatus": "unavailable"
+          },
+          "3WvsPq9LxKmNbHgTfRcDaEuY7zJ2": {
+            "state": "unknown",
+            "announcedToPeer": false,
+            "lastSyncMessageInAt": 184240.0,
+            "docSynchronizerExists": false
+          }
+        }
+      }
+    },
+    {
+      "peerId": "peer-cc33",
+      "knownInKeyring": true,
+      "presentInSignalling": false,
+      "slotInitiationRejectionReason": "not-present-in-signalling",
+      "slotInitiationDecision": {
+        "decision": "rejected",
+        "reason": "not-present-in-signalling",
+        "at": 184108.1
+      }
+    }
+  ],
+  "meshStateModule": {
+    "moduleId": "mesh-state@a1b2c3",
+    "configured": true,
+    "lastConfiguredRepoPeerId": "peer-local-7c1d",
+    "wasResolved": true,
+    "lazyInvocations": 2,
+    "lazyReachedRepo": 2,
+    "lazyWrappers": [],
+    "lazyWrapperDuplicateDocIds": []
+  },
+  "repoHandleCount": 2,
+  "repoHandleIds": ["f7sSXAhTsVrbgbbMtQYATUVQbRy", "2TWmaxBiQmvJtCrtQ6PTj4NX5eVE"]
+}

--- a/packages/polly/tools/visualize/src/__tests__/mesh-overlay.test.ts
+++ b/packages/polly/tools/visualize/src/__tests__/mesh-overlay.test.ts
@@ -1,0 +1,156 @@
+/**
+ * polly#127: the visualiser overlays a captured runtime
+ * `MeshClientPeerStateSnapshot` onto the static architecture diagram.
+ *
+ * Runs the real ArchitectureAnalyzer over the mesh-app fixture, loads
+ * the committed snapshot through the documented loader, and asserts the
+ * generated DSL carries synthesised peer nodes and status-coloured
+ * replication edges — and that, without a snapshot, the DSL is
+ * unchanged.
+ */
+
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { ArchitectureAnalyzer } from "../../../analysis/src/extract/architecture";
+import type { ArchitectureAnalysis } from "../../../analysis/src/types/architecture";
+import { generateStructurizrDSL } from "../codegen/structurizr";
+import {
+  collectSnapshotPeerIds,
+  loadMeshSnapshot,
+  MeshSnapshotError,
+  validateMeshSnapshot,
+} from "../mesh-snapshot";
+
+const projectRoot = path.join(__dirname, "fixtures/mesh-app");
+const snapshotPath = path.join(projectRoot, "snapshot.json");
+
+const analysis: ArchitectureAnalysis = await new ArchitectureAnalyzer({
+  tsConfigPath: path.join(projectRoot, "tsconfig.json"),
+  projectRoot,
+}).analyze();
+
+const snapshot = loadMeshSnapshot(snapshotPath);
+const overlayDsl = generateStructurizrDSL(analysis, { snapshot });
+
+describe("mesh sync-state overlay (polly#127)", () => {
+  test("synthesises one person node per snapshot peer", () => {
+    expect(overlayDsl).toContain('person "peer-local-7c1d" "Local mesh peer (this node)"');
+    expect(overlayDsl).toContain('person "peer-aa11" "Runtime mesh peer"');
+    expect(overlayDsl).toContain('person "peer-bb22" "Runtime mesh peer"');
+    expect(overlayDsl).toContain('person "peer-cc33" "Runtime mesh peer"');
+  });
+
+  test("tags the local peer distinctly from remote peers", () => {
+    // The local peer carries the Local tag; remote peers the plain one.
+    expect(overlayDsl).toMatch(/person "peer-local-7c1d"[^}]*tags "Local Mesh Peer"/);
+    expect(overlayDsl).toMatch(/person "peer-aa11"[^}]*tags "Mesh Peer"/);
+  });
+
+  test("overlays a coloured edge onto the matching static mesh document", () => {
+    // deriveDocumentId('chat-rooms') resolves the snapshot handle key
+    // back to the static mesh_doc_chat_rooms node.
+    expect(overlayDsl).toMatch(/-> extension\.mesh_doc_chat_rooms "has" \{\s*tags "sync:has"/);
+    expect(overlayDsl).toMatch(
+      /-> extension\.mesh_doc_chat_presence "wants" \{\s*tags "sync:wants"/
+    );
+  });
+
+  test("the edge label reflects the #112 synchronizer diagnostics", () => {
+    // docSynchronizerKnowsPeer false -> "peer not added"; a missing
+    // docSynchronizer -> "no synchronizer".
+    expect(overlayDsl).toContain('"unavailable · peer not added"');
+    expect(overlayDsl).toContain('"unknown · no synchronizer"');
+  });
+
+  test("renders a snapshot-only node for a docId static analysis missed", () => {
+    expect(overlayDsl).toContain("3WvsPq9LxKmNbHgTfRcDaEuY7zJ2");
+    expect(overlayDsl).toMatch(/mesh_doc_3wvspq9lxkmnbhgtfrcdaeuy7zj2 = container/);
+    expect(overlayDsl).toMatch(
+      /mesh_doc_3wvspq9lxkmnbhgtfrcdaeuy7zj2 = container[\s\S]*?tags "Snapshot Document"/
+    );
+    expect(overlayDsl).toMatch(
+      /-> extension\.mesh_doc_3wvspq9lxkmnbhgtfrcdaeuy7zj2 "unknown · no synchronizer" \{\s*tags "sync:unknown"/
+    );
+  });
+
+  test("a peer with no slot is rendered with no document edges", () => {
+    expect(overlayDsl).toContain('person "peer-cc33"');
+    // peer-cc33 -> ... never appears: its slot is absent.
+    expect(overlayDsl).not.toMatch(/peer_peer_cc33 ->/);
+  });
+
+  test("the styles block colours each peerDocumentStatus distinctly", () => {
+    for (const status of ["sync:has", "sync:wants", "sync:unavailable", "sync:unknown"]) {
+      expect(overlayDsl).toContain(`relationship "${status}"`);
+    }
+    expect(overlayDsl).toMatch(/relationship "sync:has"[^}]*color #2f9e44/);
+    expect(overlayDsl).toMatch(/relationship "sync:unavailable"[^}]*color #e03131/);
+    expect(overlayDsl).toContain('element "Mesh Peer"');
+    expect(overlayDsl).toContain('element "Local Mesh Peer"');
+    expect(overlayDsl).toContain('element "Snapshot Document"');
+  });
+
+  test("without a snapshot the DSL carries no overlay artefacts", () => {
+    const staticDsl = generateStructurizrDSL(analysis);
+    expect(staticDsl).not.toContain("sync:");
+    expect(staticDsl).not.toContain("Mesh Peer");
+    expect(staticDsl).not.toContain("Snapshot Document");
+    expect(staticDsl).not.toMatch(/= person "peer-/);
+    // Passing `snapshot: undefined` explicitly must behave identically
+    // to omitting it — the CLI does this on the no-snapshot path.
+    expect(generateStructurizrDSL(analysis, { snapshot: undefined })).toBe(staticDsl);
+  });
+});
+
+describe("mesh snapshot loader (polly#127)", () => {
+  test("collectSnapshotPeerIds unions local, roster, and peers[]", () => {
+    expect(collectSnapshotPeerIds(snapshot).sort()).toEqual([
+      "peer-aa11",
+      "peer-bb22",
+      "peer-cc33",
+      "peer-local-7c1d",
+    ]);
+  });
+
+  test("rejects a missing file with a clear error", () => {
+    expect(() => loadMeshSnapshot(path.join(projectRoot, "does-not-exist.json"))).toThrow(
+      MeshSnapshotError
+    );
+  });
+
+  test("rejects a non-object snapshot", () => {
+    expect(() => validateMeshSnapshot([])).toThrow(/must be a JSON object/);
+  });
+
+  test("rejects a snapshot missing localPeerId", () => {
+    expect(() => validateMeshSnapshot({ knownPeerIds: [], presentPeerIds: [], peers: [] })).toThrow(
+      /localPeerId/
+    );
+  });
+
+  test("rejects a handle with a non-boolean docSynchronizerExists", () => {
+    expect(() =>
+      validateMeshSnapshot({
+        localPeerId: "p0",
+        knownPeerIds: [],
+        presentPeerIds: [],
+        peers: [
+          {
+            peerId: "p1",
+            slot: { handles: { doc1: { docSynchronizerExists: "yes" } } },
+          },
+        ],
+      })
+    ).toThrow(/docSynchronizerExists/);
+  });
+
+  test("accepts a peer whose slot is absent", () => {
+    const ok = validateMeshSnapshot({
+      localPeerId: "p0",
+      knownPeerIds: ["p1"],
+      presentPeerIds: [],
+      peers: [{ peerId: "p1" }],
+    });
+    expect(ok.peers[0]?.peerId).toBe("p1");
+  });
+});

--- a/packages/polly/tools/visualize/src/cli.ts
+++ b/packages/polly/tools/visualize/src/cli.ts
@@ -3,9 +3,11 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { MeshClientPeerStateSnapshot } from "../../../src/shared/lib/mesh-client";
 import { analyzeArchitecture } from "../../analysis/src/extract/architecture";
 import type { ArchitectureAnalysis } from "../../analysis/src/types/architecture";
 import { generateStructurizrDSL } from "./codegen/structurizr";
+import { collectSnapshotPeerIds, loadMeshSnapshot, MeshSnapshotError } from "./mesh-snapshot";
 import { exportDiagrams } from "./runner/export";
 
 const COLORS = {
@@ -28,7 +30,7 @@ async function main() {
   switch (command) {
     case "--generate":
     case "generate":
-      await generateCommand();
+      await generateCommand(args.slice(1));
       break;
 
     case "--export":
@@ -49,22 +51,78 @@ async function main() {
       break;
 
     default:
-      await generateCommand();
+      await generateCommand(args);
   }
 }
 
-async function generateCommand() {
+async function generateCommand(args: string[]) {
   console.log(color("\n📊 Analyzing architecture...\n", COLORS.blue));
 
   try {
+    const { snapshotPath } = parseGenerateArgs(args);
+    const snapshot = snapshotPath ? loadAndReportSnapshot(snapshotPath) : undefined;
     const { tsConfigPath, projectRoot } = findAndDisplayProjectConfig();
     const analysis = await analyzeAndDisplayResults(tsConfigPath, projectRoot);
-    const dslPath = generateAndWriteDSL(analysis);
+    const dslPath = generateAndWriteDSL(analysis, snapshot);
     displayNextSteps(dslPath);
   } catch (_error) {
     // Error details logged by underlying functions
     process.exit(1);
   }
+}
+
+/** Parse the options `polly visualize generate` accepts. */
+function parseGenerateArgs(args: string[]): { snapshotPath?: string } {
+  const result: { snapshotPath?: string } = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--snapshot") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("--")) {
+        console.log(color("\n✗ --snapshot requires a file path\n", COLORS.red));
+        process.exit(1);
+      }
+      result.snapshotPath = next;
+      i++;
+    } else if (arg?.startsWith("--snapshot=")) {
+      result.snapshotPath = arg.slice("--snapshot=".length);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * polly#127: load a captured `MeshClientPeerStateSnapshot`. A malformed
+ * file is a clear error and a non-zero exit with no partial DSL. An
+ * empty snapshot (no peers beyond the local node) falls back to the
+ * static diagram with a warning.
+ */
+function loadAndReportSnapshot(snapshotPath: string): MeshClientPeerStateSnapshot | undefined {
+  let snapshot: MeshClientPeerStateSnapshot;
+  try {
+    snapshot = loadMeshSnapshot(snapshotPath);
+  } catch (error) {
+    const message = error instanceof MeshSnapshotError ? error.message : String(error);
+    console.log(color(`\n✗ Snapshot error: ${message}\n`, COLORS.red));
+    process.exit(1);
+  }
+
+  const isEmpty =
+    snapshot.knownPeerIds.length === 0 &&
+    snapshot.presentPeerIds.length === 0 &&
+    snapshot.peers.length === 0;
+  if (isEmpty) {
+    console.log(
+      color("⚠ Snapshot has no peers — generating the static diagram only.", COLORS.yellow)
+    );
+    return undefined;
+  }
+
+  const peerCount = collectSnapshotPeerIds(snapshot).length;
+  console.log(color(`✓ Loaded runtime snapshot: ${peerCount} peer(s)`, COLORS.green));
+  return snapshot;
 }
 
 function findAndDisplayProjectConfig(): { tsConfigPath: string; projectRoot: string } {
@@ -127,7 +185,10 @@ function displayArchitectureSummary(analysis: ArchitectureAnalysis): void {
   }
 }
 
-function generateAndWriteDSL(analysis: ArchitectureAnalysis): string {
+function generateAndWriteDSL(
+  analysis: ArchitectureAnalysis,
+  snapshot?: MeshClientPeerStateSnapshot
+): string {
   console.log(color("\n📝 Generating Structurizr DSL...\n", COLORS.blue));
 
   const contextTypes = Object.keys(analysis.contexts);
@@ -135,6 +196,7 @@ function generateAndWriteDSL(analysis: ArchitectureAnalysis): string {
     includeDynamicDiagrams: true,
     includeComponentDiagrams: true,
     componentDiagramContexts: contextTypes.length > 0 ? contextTypes : ["background"],
+    snapshot,
   });
 
   const outputDir = path.join(process.cwd(), "docs");
@@ -305,6 +367,10 @@ ${color("Commands:", COLORS.blue)}
   ${color("bun visualize", COLORS.green)}
   ${color("bun visualize --generate", COLORS.green)}
     Analyze codebase and generate Structurizr DSL
+
+  ${color("bun visualize generate --snapshot <path>", COLORS.green)}
+    Overlay a captured MeshClientPeerStateSnapshot — runtime mesh peers
+    and sync-state-coloured replication edges — onto the diagram
 
   ${color("bun visualize --export", COLORS.green)}
     Generate static HTML site with interactive diagrams (requires Docker)

--- a/packages/polly/tools/visualize/src/codegen/structurizr.ts
+++ b/packages/polly/tools/visualize/src/codegen/structurizr.ts
@@ -1,11 +1,17 @@
 // Structurizr DSL generator
 
+import { deriveDocumentId } from "../../../../src/shared/lib/derive-document-id";
+import type {
+  MeshClientHandleSnapshot,
+  MeshClientPeerStateSnapshot,
+} from "../../../../src/shared/lib/mesh-client";
 import type {
   ArchitectureAnalysis,
   ContextInfo,
   MessageFlow,
   MessageHandler,
 } from "../../../analysis/src";
+import { collectSnapshotPeerIds } from "../mesh-snapshot";
 import type {
   ComponentGroup,
   ComponentProperties,
@@ -19,6 +25,8 @@ import {
   DEFAULT_ELEMENT_STYLES,
   DEFAULT_RELATIONSHIP_STYLES,
   DEFAULT_THEME,
+  MESH_OVERLAY_ELEMENT_STYLES,
+  MESH_OVERLAY_RELATIONSHIP_STYLES,
 } from "../types/structurizr";
 
 // Re-export the enhanced type
@@ -53,9 +61,65 @@ const MESH_TRANSPORT_NODES = [
   },
 ] as const;
 
+/**
+ * polly#127: the four `peerDocumentStatus` buckets the overlay colours
+ * by. Automerge reports `"has"`, `"wants"`, `"unavailable"`, and
+ * `"unknown"`; an absent status (handle exists but the synchronizer
+ * has not learned the peer's state yet) also folds into `"unknown"`.
+ */
+type SyncStatus = "has" | "wants" | "unavailable" | "unknown";
+
+/** Reduce a handle snapshot to its overlay status bucket. */
+function syncStatusOf(handle: MeshClientHandleSnapshot): SyncStatus {
+  const status = handle.peerDocumentStatus;
+  if (status === "has" || status === "wants" || status === "unavailable") {
+    return status;
+  }
+  return "unknown";
+}
+
+/** A runtime peer node synthesised from the snapshot. */
+interface OverlayPeer {
+  /** DSL identifier (`peer_<id>`). */
+  id: string;
+  /** Raw peer id from the snapshot. */
+  peerId: string;
+  /** True for the peer whose snapshot this is. */
+  isLocal: boolean;
+}
+
+/** A status-coloured replication edge from a peer to a mesh document. */
+interface OverlayEdge {
+  /** Source peer DSL identifier. */
+  fromId: string;
+  /** Fully-qualified target document reference. */
+  toRef: string;
+  /** The `peerDocumentStatus` bucket — drives the `sync:<status>` tag. */
+  status: SyncStatus;
+  /** Edge label, reflecting the #112 synchronizer diagnostics. */
+  label: string;
+}
+
+/** A mesh document the snapshot references but static analysis missed. */
+interface SnapshotOnlyDoc {
+  /** DSL identifier (`mesh_doc_<id>`). */
+  id: string;
+  /** The resolved document id. */
+  docId: string;
+}
+
+/** Everything the snapshot contributes to the diagram. */
+interface OverlayPlan {
+  peers: OverlayPeer[];
+  edges: OverlayEdge[];
+  snapshotOnlyDocs: SnapshotOnlyDoc[];
+}
+
 export class StructurizrDSLGenerator {
   private analysis: ArchitectureAnalysis;
   private options: StructurizrDSLOptions;
+  /** polly#127: memoised runtime-snapshot overlay plan. */
+  private overlayPlanCache: OverlayPlan | undefined;
 
   constructor(analysis: ArchitectureAnalysis, options: StructurizrDSLOptions = {}) {
     this.analysis = analysis;
@@ -75,10 +139,14 @@ export class StructurizrDSLGenerator {
         theme: options.styles?.theme || DEFAULT_THEME,
         elements: {
           ...DEFAULT_ELEMENT_STYLES,
+          // polly#127: overlay element styles only join the set when a
+          // snapshot is supplied, keeping the static diagram unchanged.
+          ...(options.snapshot ? MESH_OVERLAY_ELEMENT_STYLES : {}),
           ...options.styles?.elements,
         },
         relationships: {
           ...DEFAULT_RELATIONSHIP_STYLES,
+          ...(options.snapshot ? MESH_OVERLAY_RELATIONSHIP_STYLES : {}),
           ...options.styles?.relationships,
         },
       },
@@ -132,6 +200,11 @@ export class StructurizrDSLGenerator {
 
     parts.push("  model {");
     parts.push(this.generatePeople());
+
+    // polly#127: runtime mesh peers synthesised from a captured snapshot
+    const meshPeers = this.generateMeshPeers();
+    if (meshPeers) parts.push(meshPeers);
+
     parts.push(this.generateExternalSystems());
     parts.push(this.generateMainSystem());
 
@@ -201,6 +274,11 @@ export class StructurizrDSLGenerator {
     // polly#114: mesh/peer documents as first-class nodes
     const meshDocs = this.generateMeshDocuments();
     if (meshDocs) parts.push(meshDocs);
+
+    // polly#127: documents the runtime snapshot references but static
+    // analysis never found
+    const snapshotDocs = this.generateSnapshotOnlyDocuments();
+    if (snapshotDocs) parts.push(snapshotDocs);
 
     // polly#114: the transport stack mesh documents sync through
     const meshTransport = this.generateMeshTransport();
@@ -867,6 +945,7 @@ export class StructurizrDSLGenerator {
     parts.push(...this.generateExternalAPIRelationships());
     parts.push(...this.generateMeshRelationships());
     parts.push(...this.generateMeshTransportRelationships());
+    parts.push(...this.generateMeshOverlayRelationships());
 
     return parts.join("\n");
   }
@@ -960,6 +1039,187 @@ export class StructurizrDSLGenerator {
       parts.push(
         `      extension.${this.meshDocId(sig.key)} -> extension.${target} "syncs through"`
       );
+    }
+    return parts;
+  }
+
+  /**
+   * polly#127: resolve the captured snapshot into the peers, edges, and
+   * snapshot-only documents it contributes. Memoised — the result is
+   * read by the model, system, and relationship passes.
+   */
+  private getOverlayPlan(): OverlayPlan | undefined {
+    const snapshot = this.options.snapshot;
+    if (!snapshot) return undefined;
+    if (!this.overlayPlanCache) {
+      this.overlayPlanCache = this.buildOverlayPlan(snapshot);
+    }
+    return this.overlayPlanCache;
+  }
+
+  /** Build the overlay plan from a validated snapshot. */
+  private buildOverlayPlan(snapshot: MeshClientPeerStateSnapshot): OverlayPlan {
+    const docIdToNode = this.buildDocIdNodeMap();
+    const { peers, peerDslById } = this.buildOverlayPeers(snapshot);
+    const { edges, snapshotOnlyDocs } = this.buildOverlayEdges(snapshot, docIdToNode, peerDslById);
+    return { peers, edges, snapshotOnlyDocs };
+  }
+
+  /**
+   * Resolve each static mesh/peer signal's logical key to its Automerge
+   * document id, so a snapshot handle (keyed by document id) can be
+   * matched back to the static `mesh_doc_*` node.
+   */
+  private buildDocIdNodeMap(): Map<string, string> {
+    const docIdToNode = new Map<string, string>();
+    const seenKeys = new Set<string>();
+    for (const sig of this.analysis.meshOrPeerSignals ?? []) {
+      if (seenKeys.has(sig.key)) continue;
+      seenKeys.add(sig.key);
+      docIdToNode.set(String(deriveDocumentId(sig.key)), this.meshDocId(sig.key));
+    }
+    return docIdToNode;
+  }
+
+  /** Synthesise one peer node per distinct peer id, with collision-safe
+   * DSL identifiers. */
+  private buildOverlayPeers(snapshot: MeshClientPeerStateSnapshot): {
+    peers: OverlayPeer[];
+    peerDslById: Map<string, string>;
+  } {
+    const peers: OverlayPeer[] = [];
+    const peerDslById = new Map<string, string>();
+    const usedPeerIds = new Set<string>();
+    for (const peerId of collectSnapshotPeerIds(snapshot)) {
+      const base = `peer_${this.toId(peerId)}`;
+      let id = base;
+      let suffix = 2;
+      while (usedPeerIds.has(id)) id = `${base}_${suffix++}`;
+      usedPeerIds.add(id);
+      peerDslById.set(peerId, id);
+      peers.push({ id, peerId, isLocal: peerId === snapshot.localPeerId });
+    }
+    return { peers, peerDslById };
+  }
+
+  /** Walk every peer's handles into status edges, collecting any
+   * document the snapshot mentions that static analysis never found. */
+  private buildOverlayEdges(
+    snapshot: MeshClientPeerStateSnapshot,
+    docIdToNode: Map<string, string>,
+    peerDslById: Map<string, string>
+  ): { edges: OverlayEdge[]; snapshotOnlyDocs: SnapshotOnlyDoc[] } {
+    const edges: OverlayEdge[] = [];
+    const snapshotOnlyDocs: SnapshotOnlyDoc[] = [];
+    const snapshotOnlyById = new Map<string, string>();
+    for (const peer of snapshot.peers) {
+      const handles = peer.slot?.handles;
+      const fromId = peerDslById.get(peer.peerId);
+      if (!handles || !fromId) continue;
+      for (const [docId, handle] of Object.entries(handles)) {
+        const nodeId = this.resolveOverlayDocNode(
+          docId,
+          docIdToNode,
+          snapshotOnlyById,
+          snapshotOnlyDocs
+        );
+        const status = syncStatusOf(handle);
+        edges.push({
+          fromId,
+          toRef: `extension.${nodeId}`,
+          status,
+          label: this.overlayEdgeLabel(status, handle),
+        });
+      }
+    }
+    return { edges, snapshotOnlyDocs };
+  }
+
+  /** Map a snapshot handle's document id onto a diagram node: a static
+   * `mesh_doc_*` node when one matches, otherwise a snapshot-only node
+   * registered on first sight. */
+  private resolveOverlayDocNode(
+    docId: string,
+    docIdToNode: Map<string, string>,
+    snapshotOnlyById: Map<string, string>,
+    snapshotOnlyDocs: SnapshotOnlyDoc[]
+  ): string {
+    const staticNode = docIdToNode.get(docId);
+    if (staticNode) return staticNode;
+    const existing = snapshotOnlyById.get(docId);
+    if (existing) return existing;
+    const nodeId = `mesh_doc_${this.toId(docId)}`;
+    snapshotOnlyById.set(docId, nodeId);
+    snapshotOnlyDocs.push({ id: nodeId, docId });
+    return nodeId;
+  }
+
+  /**
+   * polly#127: the edge label carries the status and, when the #112
+   * synchronizer diagnostics show a degraded handle, the fingerprint —
+   * a missing docSynchronizer or a synchronizer that never learned the
+   * peer.
+   */
+  private overlayEdgeLabel(status: SyncStatus, handle: MeshClientHandleSnapshot): string {
+    if (!handle.docSynchronizerExists) return `${status} · no synchronizer`;
+    if (handle.docSynchronizerKnowsPeer === false) return `${status} · peer not added`;
+    return status;
+  }
+
+  /**
+   * polly#127: emit each runtime peer as a `person` at model scope. The
+   * local peer is tagged distinctly from the remote peers.
+   */
+  private generateMeshPeers(): string {
+    const plan = this.getOverlayPlan();
+    if (!plan || plan.peers.length === 0) return "";
+
+    const parts: string[] = [];
+    for (const peer of plan.peers) {
+      const tag = peer.isLocal ? "Local Mesh Peer" : "Mesh Peer";
+      const description = peer.isLocal ? "Local mesh peer (this node)" : "Runtime mesh peer";
+      parts.push(`    ${peer.id} = person "${this.escape(peer.peerId)}" "${description}" {`);
+      parts.push(`      tags "${tag}"`);
+      parts.push("    }");
+    }
+    return parts.join("\n");
+  }
+
+  /**
+   * polly#127: emit a container for each document the snapshot
+   * references that the static analysis did not find — drawn distinctly
+   * so it reads as runtime-only rather than dropped.
+   */
+  private generateSnapshotOnlyDocuments(): string {
+    const plan = this.getOverlayPlan();
+    if (!plan || plan.snapshotOnlyDocs.length === 0) return "";
+
+    const parts: string[] = [];
+    for (const doc of plan.snapshotOnlyDocs) {
+      const description = `Mesh document seen only in the runtime snapshot — docId ${doc.docId}`;
+      parts.push(
+        `      ${doc.id} = container "${this.escape(doc.docId)}" "${this.escape(description)}" "snapshot" {`
+      );
+      parts.push('        tags "Snapshot Document"');
+      parts.push("      }");
+    }
+    return parts.join("\n");
+  }
+
+  /**
+   * polly#127: emit a `sync:<status>`-tagged edge from each peer to the
+   * mesh document it holds a handle for, colour-coded by the live
+   * `peerDocumentStatus`.
+   */
+  private generateMeshOverlayRelationships(): string[] {
+    const plan = this.getOverlayPlan();
+    if (!plan) return [];
+
+    const parts: string[] = [];
+    for (const edge of plan.edges) {
+      parts.push(`      ${edge.fromId} -> ${edge.toRef} "${this.escape(edge.label)}" {`);
+      parts.push(`        tags "sync:${edge.status}"`);
+      parts.push("      }");
     }
     return parts;
   }

--- a/packages/polly/tools/visualize/src/index.ts
+++ b/packages/polly/tools/visualize/src/index.ts
@@ -4,6 +4,8 @@
 export { type ArchitectureAnalysis, analyzeArchitecture } from "../../analysis/src/index.ts";
 // Export DSL generator
 export * from "./codegen/structurizr";
+// polly#127: export the runtime mesh-overlay snapshot loader/validator
+export * from "./mesh-snapshot";
 // Export diagram exporter
 export * from "./runner/export";
 // Export interactive viewer

--- a/packages/polly/tools/visualize/src/mesh-snapshot.ts
+++ b/packages/polly/tools/visualize/src/mesh-snapshot.ts
@@ -1,0 +1,127 @@
+// polly#127: load and validate a captured MeshClientPeerStateSnapshot
+// for the visualiser's runtime sync-state overlay.
+
+import * as fs from "node:fs";
+import type {
+  MeshClientHandleSnapshot,
+  MeshClientPeerStateSnapshot,
+} from "../../../src/shared/lib/mesh-client";
+
+/** Thrown when a `--snapshot` file is missing, unreadable, or does not
+ * match the {@link MeshClientPeerStateSnapshot} shape. The CLI turns it
+ * into a clear message and a non-zero exit with no partial DSL. */
+export class MeshSnapshotError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MeshSnapshotError";
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireStringArray(value: unknown, path: string): string[] {
+  if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+    throw new MeshSnapshotError(`${path} must be an array of strings`);
+  }
+  return value as string[];
+}
+
+/** Validate one per-document handle entry. Only the fields the overlay
+ * reads are checked; everything else is passed through untouched. */
+function validateHandle(value: unknown, path: string): MeshClientHandleSnapshot {
+  if (!isObject(value)) {
+    throw new MeshSnapshotError(`${path} must be an object`);
+  }
+  if (typeof value["docSynchronizerExists"] !== "boolean") {
+    throw new MeshSnapshotError(`${path}.docSynchronizerExists must be a boolean`);
+  }
+  const knowsPeer = value["docSynchronizerKnowsPeer"];
+  if (knowsPeer !== undefined && typeof knowsPeer !== "boolean") {
+    throw new MeshSnapshotError(`${path}.docSynchronizerKnowsPeer must be a boolean or absent`);
+  }
+  const status = value["peerDocumentStatus"];
+  if (status !== undefined && typeof status !== "string") {
+    throw new MeshSnapshotError(`${path}.peerDocumentStatus must be a string or absent`);
+  }
+  return value as unknown as MeshClientHandleSnapshot;
+}
+
+function validatePeer(value: unknown, path: string): MeshClientPeerStateSnapshot["peers"][number] {
+  if (!isObject(value)) {
+    throw new MeshSnapshotError(`${path} must be an object`);
+  }
+  if (typeof value["peerId"] !== "string") {
+    throw new MeshSnapshotError(`${path}.peerId must be a string`);
+  }
+  // A peer with no negotiated slot serialises as an omitted key; a
+  // hand-authored snapshot may use an explicit null. Both mean "absent".
+  const slot = value["slot"];
+  if (slot !== undefined && slot !== null) {
+    if (!isObject(slot)) {
+      throw new MeshSnapshotError(`${path}.slot must be an object or absent`);
+    }
+    const handles = slot["handles"];
+    if (!isObject(handles)) {
+      throw new MeshSnapshotError(`${path}.slot.handles must be an object`);
+    }
+    for (const [docId, handle] of Object.entries(handles)) {
+      validateHandle(handle, `${path}.slot.handles[${docId}]`);
+    }
+  }
+  return value as unknown as MeshClientPeerStateSnapshot["peers"][number];
+}
+
+/** Validate a parsed JSON value against the snapshot contract. */
+export function validateMeshSnapshot(data: unknown): MeshClientPeerStateSnapshot {
+  if (!isObject(data)) {
+    throw new MeshSnapshotError("snapshot must be a JSON object");
+  }
+  if (typeof data["localPeerId"] !== "string") {
+    throw new MeshSnapshotError("snapshot.localPeerId must be a string");
+  }
+  requireStringArray(data["knownPeerIds"], "snapshot.knownPeerIds");
+  requireStringArray(data["presentPeerIds"], "snapshot.presentPeerIds");
+  const peers = data["peers"];
+  if (!Array.isArray(peers)) {
+    throw new MeshSnapshotError("snapshot.peers must be an array");
+  }
+  peers.forEach((peer, i) => {
+    validatePeer(peer, `snapshot.peers[${i}]`);
+  });
+  return data as unknown as MeshClientPeerStateSnapshot;
+}
+
+/** Read, parse, and validate a `MeshClientPeerStateSnapshot` JSON file.
+ * Throws {@link MeshSnapshotError} with a clear message on any failure. */
+export function loadMeshSnapshot(filePath: string): MeshClientPeerStateSnapshot {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new MeshSnapshotError(`cannot read snapshot file '${filePath}': ${reason}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new MeshSnapshotError(`snapshot file '${filePath}' is not valid JSON: ${reason}`);
+  }
+
+  return validateMeshSnapshot(parsed);
+}
+
+/** Every distinct peer id the snapshot mentions: the local peer, the
+ * keyring/signalling rosters, and every entry in `peers[]`. The overlay
+ * synthesises one diagram node per id. */
+export function collectSnapshotPeerIds(snapshot: MeshClientPeerStateSnapshot): string[] {
+  const ids = new Set<string>([snapshot.localPeerId]);
+  for (const id of snapshot.knownPeerIds) ids.add(id);
+  for (const id of snapshot.presentPeerIds) ids.add(id);
+  for (const peer of snapshot.peers) ids.add(peer.peerId);
+  return [...ids];
+}

--- a/packages/polly/tools/visualize/src/types/structurizr.ts
+++ b/packages/polly/tools/visualize/src/types/structurizr.ts
@@ -1,5 +1,7 @@
 // Strict types for Structurizr DSL generation
 
+import type { MeshClientPeerStateSnapshot } from "../../../../src/shared/lib/mesh-client";
+
 /**
  * Shape options for elements in Structurizr diagrams
  */
@@ -241,6 +243,14 @@ export interface StructurizrDSLOptions {
 
   /** Deployment nodes */
   deploymentNodes?: DeploymentNode[];
+
+  /**
+   * polly#127: a captured `MeshClientPeerStateSnapshot`. When present,
+   * the generator overlays runtime mesh peers and status-coloured
+   * replication edges onto the static `mesh_doc_*` nodes. Absent, the
+   * static diagram is emitted unchanged.
+   */
+  snapshot?: MeshClientPeerStateSnapshot;
 }
 
 /**
@@ -364,6 +374,63 @@ export const DEFAULT_RELATIONSHIP_STYLES: Record<string, RelationshipStyle> = {
     style: "Solid",
     thickness: 3,
     color: DEFAULT_COLORS.database,
+  },
+};
+
+/**
+ * polly#127: element styles for the runtime mesh-overlay. Merged into
+ * the style set only when a snapshot is supplied, so the static
+ * diagram stays byte-identical without one.
+ */
+export const MESH_OVERLAY_ELEMENT_STYLES: Record<string, ElementStyle> = {
+  // A runtime peer synthesised from the snapshot — another device's
+  // copy of the mesh, not part of this codebase.
+  "Mesh Peer": {
+    shape: "Person",
+    background: "#495057",
+    color: DEFAULT_COLORS.textLight,
+  },
+  // The peer whose snapshot this is — the local node.
+  "Local Mesh Peer": {
+    shape: "Person",
+    background: DEFAULT_COLORS.messageHandler,
+    color: DEFAULT_COLORS.textLight,
+  },
+  // A mesh document the snapshot references but the static analysis
+  // never found — drawn dashed to read as "runtime only".
+  "Snapshot Document": {
+    shape: "Cylinder",
+    background: "#adb5bd",
+    color: DEFAULT_COLORS.textDark,
+    border: "Dashed",
+  },
+};
+
+/**
+ * polly#127: relationship styles colouring each `peerDocumentStatus`.
+ * Keyed by the `sync:<status>` tag emitted on overlay edges. Merged in
+ * only alongside a snapshot.
+ */
+export const MESH_OVERLAY_RELATIONSHIP_STYLES: Record<string, RelationshipStyle> = {
+  "sync:has": {
+    color: "#2f9e44",
+    style: "Solid",
+    thickness: 3,
+  },
+  "sync:wants": {
+    color: "#f08c00",
+    style: "Dashed",
+    thickness: 2,
+  },
+  "sync:unavailable": {
+    color: "#e03131",
+    style: "Dashed",
+    thickness: 2,
+  },
+  "sync:unknown": {
+    color: "#868e96",
+    style: "Dotted",
+    thickness: 2,
   },
 };
 


### PR DESCRIPTION
Closes #127.

`polly visualize generate --snapshot <path>` ingests a captured `MeshClientPeerStateSnapshot` and renders it as a runtime overlay on the architecture diagram. This closes the diagnostic loop #112 opened: a captured runtime snapshot replayed against the static picture.

## What it does

- **Runtime peers** become synthesised `person` nodes — `localPeerId`, the keyring and signalling rosters, and every `peers[]` entry — with the local peer tagged distinctly from the remote ones.
- **Each per-document handle** becomes an edge into the matching `mesh_doc_*` container, tagged `sync:<peerDocumentStatus>` and colour-coded: green for `has`, amber for `wants`, red for `unavailable`, grey for `unknown`.
- **Edge labels** carry the #112 synchronizer diagnostics, so a wedged pair reads as `unavailable · peer not added` or `unknown · no synchronizer` rather than a bare status.
- A document the snapshot references but static analysis never found is drawn as its own snapshot-only node rather than dropped.
- Without `--snapshot`, the generated DSL is byte-identical to before.

## The docId bridge

A snapshot handle is keyed by its Automerge document id, whilst the static `mesh_doc_*` nodes are keyed by logical key. `deriveDocumentId` bridges the two, so an overlay edge lands on the real static node.

To keep that bridge cheap for tooling, `deriveDocumentId` moves into its own leaf module — free of the wider mesh runtime — which `mesh-state` imports and re-exports, so `@fairfox/polly/mesh` consumer imports are unchanged.

## Design notes

- Overlay element and relationship styles are separate constants, merged into the style set only when a snapshot is supplied. This is what keeps the no-snapshot diagram byte-identical.
- Peer nodes are `person` elements, so they read as runtime actors distinct from the static codebase containers.

## Verification

`scripts/e2e-visualize.ts` gains a `mesh-overlay` case that runs the real `polly` CLI with `--snapshot` against the mesh-app fixture and validates the output through Structurizr. Full typecheck, biome, the unit suite, the visualiser tests, and the library build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)