### PR TITLE
fix: render ActionSelect and Select triggers as proper dropdowns (#131)

### DIFF
--- a/packages/polly/CHANGELOG.md
+++ b/packages/polly/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.74.0] - 2026-05-22
+
+### Fixed
+
+#### `<ActionSelect>` and `<Select>` triggers render as proper dropdowns (polly#131)
+
+`<Dropdown>` wraps whatever trigger it is given in its own `<button>`.
+`<ActionSelect>` passed it a styled `<span>`, so the visible bordered
+box and the focusable, clickable element were two different DOM nodes
+that could drift apart; `<Select>` passed a styled `<button>`, nesting
+one button inside another. Neither trigger carried a caret, so the
+control was indistinguishable from a plain text input, and a
+hardcoded `min-width: 140px` made every select wider than its
+contents needed.
+
+`<Dropdown>` now accepts `triggerClassName` and `triggerDisabled`
+props and styles its own button directly, so the border, background,
+and a `▾` caret all land on the single interactive element. The
+trigger sizes to its content by default; a new `wide` prop on
+`<Select>` and `<ActionSelect>` opts back into a comfortable minimum
+width where it is wanted. A disabled `<ActionSelect>` still renders as
+static text, now without a caret.
+
 ## [0.73.1] - 2026-05-21
 
 ### Fixed

--- a/packages/polly/package.json
+++ b/packages/polly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.73.1",
+  "version": "0.74.0",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/packages/polly/src/polly-ui/ActionSelect.tsx
+++ b/packages/polly/src/polly-ui/ActionSelect.tsx
@@ -9,9 +9,11 @@
  * <ActionInput> and <ActionForm>, with no synthetic signal or bridging
  * `effect` required.
  *
- * Composes <Dropdown> for the menu. The trigger is a plain <span> (not a
- * nested <button>) so the Dropdown's own button is the single
- * interactive element. A disabled ActionSelect renders as static text.
+ * Composes <Dropdown> for the menu. The trigger styling is applied
+ * directly to Dropdown's own <button> via `triggerClassName`, so the
+ * visible box and the interactive element are one and the same node —
+ * no styled <span> nested inside an unstyled <button>. A disabled
+ * ActionSelect renders as static text without a caret.
  */
 
 import { useSignal } from "@preact/signals";
@@ -36,6 +38,8 @@ export type ActionSelectProps = PassthroughAttrs & {
   /** Trigger text shown when `value` matches no option. Default: "Select…". */
   placeholder?: string;
   disabled?: boolean;
+  /** Apply a comfortable minimum width to the trigger. Default: sizes to content. */
+  wide?: boolean;
   className?: string;
   id?: string;
 };
@@ -56,6 +60,7 @@ export function ActionSelect(props: ActionSelectProps): JSX.Element {
     label,
     placeholder = "Select…",
     disabled = false,
+    wide = false,
     className,
     id,
   } = props;
@@ -72,9 +77,10 @@ export function ActionSelect(props: ActionSelectProps): JSX.Element {
     dispatchAction(action, { ...(actionData ?? {}), value: next });
   };
 
-  const triggerClass = isEmpty
-    ? `${classes["trigger"]} ${classes["placeholder"]}`
-    : classes["trigger"];
+  const triggerParts = [classes["trigger"] ?? ""];
+  if (isEmpty) triggerParts.push(classes["placeholder"] ?? "");
+  if (wide) triggerParts.push(classes["triggerWide"] ?? "");
+  const triggerClass = triggerParts.filter(Boolean).join(" ");
 
   const parts = [classes["select"] ?? ""];
   if (className) parts.push(className);
@@ -91,10 +97,19 @@ export function ActionSelect(props: ActionSelectProps): JSX.Element {
       {label !== undefined && <span class={classes["label"]}>{label}</span>}
       {disabled ? (
         <span class={triggerClass} aria-disabled="true">
-          {displayText}
+          <span class={classes["triggerLabel"]}>{displayText}</span>
         </span>
       ) : (
-        <Dropdown isOpen={isOpen} trigger={<span class={triggerClass}>{displayText}</span>}>
+        <Dropdown
+          isOpen={isOpen}
+          triggerClassName={triggerClass}
+          trigger={
+            <>
+              <span class={classes["triggerLabel"]}>{displayText}</span>
+              <span class={classes["caret"]} aria-hidden="true" />
+            </>
+          }
+        >
           {options.map((opt) => {
             const isSelected = opt.value === value;
             const optClass = isSelected

--- a/packages/polly/src/polly-ui/Dropdown.tsx
+++ b/packages/polly/src/polly-ui/Dropdown.tsx
@@ -29,6 +29,15 @@ export type DropdownProps = {
   align?: "left" | "right";
   multiSelect?: boolean;
   className?: string;
+  /**
+   * Class applied to the trigger <button> in place of Dropdown's own
+   * default. Lets a composing component (Select, ActionSelect) style
+   * the single interactive element directly, with no styled node
+   * nested inside the button.
+   */
+  triggerClassName?: string;
+  /** Disables the trigger <button>. */
+  triggerDisabled?: boolean;
   id?: string;
 };
 
@@ -40,7 +49,17 @@ const MENU_GAP = 4;
 const VIEWPORT_PADDING = 8;
 
 export function Dropdown(props: DropdownProps): JSX.Element {
-  const { isOpen, trigger, children, align = "left", multiSelect = false, className, id } = props;
+  const {
+    isOpen,
+    trigger,
+    children,
+    align = "left",
+    multiSelect = false,
+    className,
+    triggerClassName,
+    triggerDisabled = false,
+    id,
+  } = props;
 
   const menuRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -172,7 +191,12 @@ export function Dropdown(props: DropdownProps): JSX.Element {
 
   return (
     <div id={id} class={parts.filter(Boolean).join(" ")} data-polly-ui data-polly-dropdown>
-      <button ref={triggerRef} type="button" class={classes["trigger"]}>
+      <button
+        ref={triggerRef}
+        type="button"
+        class={triggerClassName ?? classes["trigger"] ?? ""}
+        disabled={triggerDisabled}
+      >
         {trigger}
       </button>
       <div

--- a/packages/polly/src/polly-ui/Select.module.css
+++ b/packages/polly/src/polly-ui/Select.module.css
@@ -11,9 +11,18 @@
     color: var(--polly-text-muted);
   }
 
+  /*
+   * The trigger is the single interactive element — applied directly
+   * to <Select>'s <button> and, via Dropdown's `triggerClassName`, to
+   * <ActionSelect>'s <button>. inline-flex lays out the label and the
+   * caret as siblings; intrinsic width by default (`.triggerWide`
+   * opts into a minimum).
+   */
   .trigger {
-    display: inline-block;
-    min-width: 140px;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--polly-space-sm);
+    max-width: 100%;
     padding: var(--polly-space-sm) var(--polly-space-md);
     border: var(--polly-border-width-default) solid var(--polly-border);
     border-radius: var(--polly-radius-sm);
@@ -23,14 +32,40 @@
     color: var(--polly-text);
     text-align: left;
     cursor: pointer;
+  }
+
+  .trigger:disabled,
+  .trigger[aria-disabled="true"] {
+    opacity: var(--polly-opacity-disabled);
+    cursor: not-allowed;
+  }
+
+  /* Opt-in: widen short selects to a comfortable minimum. */
+  .triggerWide {
+    min-width: 140px;
+  }
+
+  /* The label shrinks (min-width: 0) so long text ellipsis-truncates
+     while the caret keeps its intrinsic size. */
+  .triggerLabel {
+    flex: 1 1 auto;
+    min-width: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  .trigger:disabled {
-    opacity: var(--polly-opacity-disabled);
-    cursor: not-allowed;
+  .caret {
+    flex: none;
+    color: var(--polly-text-muted);
+    pointer-events: none;
+  }
+
+  .caret::before {
+    content: "\25BE";
+    display: block;
+    font-size: var(--polly-text-xs);
+    line-height: 1;
   }
 
   .placeholder {

--- a/packages/polly/src/polly-ui/Select.tsx
+++ b/packages/polly/src/polly-ui/Select.tsx
@@ -23,6 +23,8 @@ export type SelectProps<T = string> = {
   placeholder?: string;
   multiSelect?: boolean;
   disabled?: boolean;
+  /** Apply a comfortable minimum width to the trigger. Default: sizes to content. */
+  wide?: boolean;
   className?: string;
   id?: string;
 };
@@ -44,6 +46,7 @@ export function Select<T = string>(props: SelectProps<T>): JSX.Element {
     placeholder = "Select\u2026",
     multiSelect = false,
     disabled = false,
+    wide = false,
     className,
     id,
   } = props;
@@ -77,13 +80,15 @@ export function Select<T = string>(props: SelectProps<T>): JSX.Element {
     selected.value = new Set();
   };
 
-  const triggerClass = isEmpty.value
-    ? `${classes["trigger"]} ${classes["placeholder"]}`
-    : classes["trigger"];
-  const triggerButton = (
-    <button type="button" class={triggerClass} disabled={disabled}>
-      {displayText.value}
-    </button>
+  const triggerParts = [classes["trigger"] ?? ""];
+  if (isEmpty.value) triggerParts.push(classes["placeholder"] ?? "");
+  if (wide) triggerParts.push(classes["triggerWide"] ?? "");
+  const triggerClass = triggerParts.filter(Boolean).join(" ");
+  const triggerContent = (
+    <>
+      <span class={classes["triggerLabel"]}>{displayText.value}</span>
+      <span class={classes["caret"]} aria-hidden="true" />
+    </>
   );
 
   const parts = [classes["select"] ?? ""];
@@ -92,7 +97,13 @@ export function Select<T = string>(props: SelectProps<T>): JSX.Element {
   return (
     <div id={id} class={parts.filter(Boolean).join(" ")} data-polly-ui data-polly-select>
       {label !== undefined && <span class={classes["label"]}>{label}</span>}
-      <Dropdown isOpen={isOpen} trigger={triggerButton} multiSelect={multiSelect}>
+      <Dropdown
+        isOpen={isOpen}
+        trigger={triggerContent}
+        triggerClassName={triggerClass}
+        triggerDisabled={disabled}
+        multiSelect={multiSelect}
+      >
         {multiSelect && (
           <div class={classes["actions"]}>
             <Layout columns="1fr 1fr" gap="var(--polly-space-xs)">

--- a/packages/polly/tests/unit/polly-ui-components.test.ts
+++ b/packages/polly/tests/unit/polly-ui-components.test.ts
@@ -30,6 +30,8 @@ const { Surface } = await import("../../src/polly-ui/Surface.tsx");
 const { Button } = await import("../../src/polly-ui/Button.tsx");
 const { ActionInput } = await import("../../src/polly-ui/ActionInput.tsx");
 const { ActionSelect } = await import("../../src/polly-ui/ActionSelect.tsx");
+const { Select } = await import("../../src/polly-ui/Select.tsx");
+const { signal } = await import("@preact/signals");
 const { dispatchAction } = await import("../../src/polly-ui/internal/dispatch-action.ts");
 
 function mount<P>(vnode: VNode<P>): HTMLElement {
@@ -347,5 +349,85 @@ describe("ActionSelect", () => {
     );
     expect(el.getAttribute("data-status-select")).toBe("true");
     expect(el.getAttribute("data-polly-action-select")).not.toBeNull();
+  });
+
+  test("trigger is a single <button> carrying a caret affordance (polly#131)", () => {
+    const el = rendered(
+      mount(
+        h(ActionSelect, {
+          value: "open",
+          action: "task:set-status",
+          options: [
+            { value: "open", label: "Open" },
+            { value: "done", label: "Done" },
+          ],
+        })
+      )
+    );
+    const button = el.querySelector("[data-polly-dropdown] > button");
+    // The interactive element is the styled box itself — not a styled
+    // <span> nested inside an unstyled <button>.
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain("Open");
+    // A caret marks it as a dropdown; it is hidden from the a11y tree.
+    const caret = button?.querySelector('[aria-hidden="true"]');
+    expect(caret).not.toBeNull();
+    // Nothing interactive is nested inside the trigger button.
+    expect(button?.querySelector("button, select, input")).toBeNull();
+  });
+
+  test("disabled trigger renders as static text with no caret (polly#131)", () => {
+    const el = rendered(
+      mount(
+        h(ActionSelect, {
+          value: "open",
+          action: "task:set-status",
+          disabled: true,
+          options: [{ value: "open", label: "Open" }],
+        })
+      )
+    );
+    // No Dropdown, no interactive trigger, no caret affordance.
+    expect(el.querySelector("[data-polly-dropdown]")).toBeNull();
+    expect(el.querySelector("button")).toBeNull();
+    expect(el.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(el.textContent).toContain("Open");
+  });
+});
+
+describe("Select", () => {
+  test("trigger is the <button> itself, with a caret, no nested button (polly#131)", () => {
+    const el = rendered(
+      mount(
+        h(Select, {
+          selected: signal(new Set(["a"])),
+          options: [
+            { value: "a", label: "Alpha" },
+            { value: "b", label: "Beta" },
+          ],
+        })
+      )
+    );
+    const button = el.querySelector("[data-polly-dropdown] > button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain("Alpha");
+    expect(button?.querySelector('[aria-hidden="true"]')).not.toBeNull();
+    // The old shape nested a styled <button> inside Dropdown's button.
+    expect(button?.querySelector("button")).toBeNull();
+  });
+
+  test("disabled propagates to the trigger button (polly#131)", () => {
+    const el = rendered(
+      mount(
+        h(Select, {
+          selected: signal(new Set<string>()),
+          disabled: true,
+          options: [{ value: "a", label: "Alpha" }],
+        })
+      )
+    );
+    const button = el.querySelector("[data-polly-dropdown] > button");
+    expect(button).not.toBeNull();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #131.

`<Dropdown>` wraps whatever trigger it is given in its own `<button>`. `<ActionSelect>` handed it a styled `<span>` and `<Select>` a styled `<button>`, so the visible bordered box and the focusable, clickable element were two different DOM nodes that could drift apart. Neither trigger carried a caret, leaving the control indistinguishable from a plain text input, and a hardcoded `min-width: 140px` oversized every select.

`<Dropdown>` now exposes `triggerClassName` and `triggerDisabled` props and styles its own button directly, so the border, background, and a `▾` caret all land on the single interactive element. The trigger sizes to its content by default; a new `wide` prop on `<Select>` and `<ActionSelect>` opts back into a comfortable minimum width. A disabled `<ActionSelect>` still renders as static text, now without a caret.

Bumps to 0.74.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)