### PR TITLE
fix: re-discover a mesh peer that rejoins after a topology change (polly#133)

### DIFF
--- a/packages/polly/CHANGELOG.md
+++ b/packages/polly/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.74.1] - 2026-05-22
+
+### Fixed
+
+#### Survivor re-discovers a peer that rejoins after a topology change (polly#133)
+
+When a mesh peer dies and another peer later joins under a peerId an
+earlier session had already used, a surviving peer could fail to
+reconnect to the newcomer. The survivor still held a `PeerSlot` from
+the peerId's previous incarnation: `handlePeerJoined` saw
+`slot-already-exists` and declined to re-dial, and the glare rule in
+`handleOffer` made the lexicographically-higher survivor ignore the
+newcomer's offer as well. The pair stayed apart until the idle-slot
+watchdog reaped the dead slot two minutes later — long after the
+request that prompted the rejoin had given up. A CLI command re-run
+from the same keyring, which derives the same peerId every time, is
+the canonical trigger.
+
+A `peer-joined` or `peers-present` frame is now treated as proof that
+the remote peer's signalling presence is fresh: a slot held for that
+peerId is torn down before the dial path runs, so the survivor
+rebuilds the connection immediately. The one slot shape that survives
+the check is a data channel still `open` on a `connected` connection —
+the peer kept its direct WebRTC session across a signalling reconnect,
+and signalling churn is irrelevant to it. A young, still-negotiating
+handshake is also left untouched, so a duplicate discovery frame
+cannot restart a connection that simply is not done yet.
+
 ## [0.74.0] - 2026-05-22
 
 ### Fixed

--- a/packages/polly/package.json
+++ b/packages/polly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairfox/polly",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "private": false,
   "type": "module",
   "description": "Multi-execution-context framework with reactive state and cross-context messaging for Chrome extensions, PWAs, and worker-based applications",

--- a/packages/polly/src/shared/lib/mesh-webrtc-adapter.ts
+++ b/packages/polly/src/shared/lib/mesh-webrtc-adapter.ts
@@ -1014,9 +1014,17 @@ export class MeshWebRTCAdapter extends NetworkAdapter {
    * theirs), open an initiating slot and fire the SDP offer. Otherwise
    * do nothing — either we are not interested in this peer, we are
    * already connected, or the other side is the one expected to
-   * initiate. */
+   * initiate.
+   *
+   * A `peer-joined` for a peerId we already hold a slot for is first
+   * routed through {@link evictStaleSlotForRejoin}: the notification is
+   * authoritative proof the remote peer's signalling presence is fresh,
+   * so a slot left over from an earlier incarnation of the same peerId
+   * is torn down rather than left to wedge rediscovery. Polly issue
+   * #133. */
   handlePeerJoined(remotePeerId: string): void {
     this.presentPeers.add(remotePeerId);
+    this.evictStaleSlotForRejoin(remotePeerId);
     if (!this.shouldInitiateTo(remotePeerId)) return;
     this.tryCreateInitiatingSlot(remotePeerId);
   }
@@ -1024,13 +1032,71 @@ export class MeshWebRTCAdapter extends NetworkAdapter {
   /** Handle the signalling server's `peers-present` notification sent
    * once to a newcomer. Applies the same filter as handlePeerJoined to
    * every listed peer, so a device joining into an established lobby
-   * dials every knownPeer it is meant to initiate to in one pass. */
+   * dials every knownPeer it is meant to initiate to in one pass.
+   *
+   * Like {@link handlePeerJoined}, each listed peer is first run
+   * through {@link evictStaleSlotForRejoin} so a `peers-present` frame
+   * received on a signalling *reconnect* clears any stale slot before
+   * the dial path re-evaluates it. Polly issue #133. */
   handlePeersPresent(peerIds: string[]): void {
     for (const remotePeerId of peerIds) {
       this.presentPeers.add(remotePeerId);
+      this.evictStaleSlotForRejoin(remotePeerId);
       if (!this.shouldInitiateTo(remotePeerId)) continue;
       this.tryCreateInitiatingSlot(remotePeerId);
     }
+  }
+
+  /** Tear down a slot left over from an earlier incarnation of a peer
+   * that has just (re)appeared in the signalling roster, so the dial
+   * path can rebuild it.
+   *
+   * A `peer-joined` / `peers-present` frame is authoritative proof that
+   * the remote peer's signalling presence is fresh: its
+   * {@link MeshSignalingClient} has just sent a `join`. If we are still
+   * holding a slot for that peerId, the slot belongs to a previous
+   * incarnation — *unless* the peer kept a live WebRTC session across
+   * its own signalling reconnect, in which case the data channel is
+   * still `open` on a `connected` connection and the slot is genuinely
+   * sound (peers talk directly once the channel is up; signalling is
+   * intermittent). That one shape is kept; every other shape is stale.
+   *
+   * Polly issue #133: before this, a stale slot wedged rediscovery of a
+   * peer that reuses its peerId across short-lived sessions (a CLI
+   * `chat send` re-run from the same keyring is the canonical case).
+   * The `slot-already-exists` gate in {@link evaluateInitiation}
+   * blocked the survivor from re-dialling, and {@link handleOffer}'s
+   * glare rule made the lexicographically-higher survivor ignore the
+   * newcomer's offer too — so the pair never reconnected until the
+   * {@link slotIdleTimeoutMs} watchdog reaped the corpse, far too late
+   * for the request that triggered the rejoin.
+   *
+   * A handshake that is still young and negotiating (`new`/`connecting`
+   * within {@link slotNeverConnectedTimeoutMs}) is left alone — a
+   * duplicate frame arriving mid-handshake must not nuke a connection
+   * that simply is not done yet. */
+  private evictStaleSlotForRejoin(remotePeerId: string): void {
+    const slot = this.slots.get(remotePeerId);
+    if (!slot) return;
+    const state = slot.connection.connectionState;
+    // The peer kept a live, data-carrying channel across its signalling
+    // reconnect — the slot is sound, keep it.
+    if (state === "connected" && slot.channel?.readyState === "open") return;
+    // A handshake still in flight and young enough to plausibly
+    // complete — don't restart it on a duplicate discovery frame.
+    if (
+      this.slotNeverConnectedTimeoutMs > 0 &&
+      (state === "new" || state === "connecting") &&
+      performance.now() - slot.createdAt < this.slotNeverConnectedTimeoutMs
+    ) {
+      return;
+    }
+    // Anything else — a stuck or dead connection, or one whose channel
+    // never opened — is a stale slot from an earlier incarnation.
+    // tearDownWedgedSlot removes it from the map and emits
+    // `peer-disconnected` so Automerge stops routing through it; the
+    // caller's dial path then rebuilds against the fresh peer.
+    this.tearDownWedgedSlot(remotePeerId);
   }
 
   /** Construct an initiating slot inside a per-peer try/catch and

--- a/packages/polly/tests/unit/mesh-webrtc-adapter-peer-joined.test.ts
+++ b/packages/polly/tests/unit/mesh-webrtc-adapter-peer-joined.test.ts
@@ -44,6 +44,7 @@ class FakeDataChannel {
   onopen: (() => void) | null = null;
   onmessage: ((ev: { data: ArrayBuffer | Uint8Array }) => void) | null = null;
   onclose: (() => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
   readyState = "connecting";
   close(): void {
     this.readyState = "closed";
@@ -53,12 +54,28 @@ class FakeDataChannel {
 }
 
 class FakePeerConnection {
+  // Every FakePeerConnection registers itself here so a test can reach
+  // the connection the adapter built for a peer and drive its
+  // `connectionState` — the polly#133 stale-slot tests need to put a
+  // slot into a dead or fully-live shape after construction.
+  static instances: FakePeerConnection[] = [];
+  static reset(): void {
+    FakePeerConnection.instances = [];
+  }
   onicecandidate: ((ev: { candidate: unknown }) => void) | null = null;
   onconnectionstatechange: (() => void) | null = null;
   ondatachannel: ((ev: { channel: FakeDataChannel }) => void) | null = null;
   connectionState = "new";
+  /** The data channel handed back from {@link createDataChannel} on an
+   * initiating slot, exposed so a test can flip its `readyState`. */
+  lastDataChannel: FakeDataChannel | undefined;
+  constructor() {
+    FakePeerConnection.instances.push(this);
+  }
   createDataChannel(_label: string, _options: unknown): FakeDataChannel {
-    return new FakeDataChannel();
+    const channel = new FakeDataChannel();
+    this.lastDataChannel = channel;
+    return channel;
   }
   async createOffer(): Promise<RTCSessionDescriptionInit> {
     return { type: "offer", sdp: "v=0\r\nfake\r\n" };
@@ -111,14 +128,17 @@ function createSignalingStub(peerId: string): {
 
 function buildAdapter(
   localPeerId: string,
-  knownPeerIds: string[]
+  knownPeerIds: string[],
+  overrides: { slotNeverConnectedTimeoutMs?: number } = {}
 ): { adapter: MeshWebRTCAdapter; sent: SentSignal[] } {
+  FakePeerConnection.reset();
   const { client, sent } = createSignalingStub(localPeerId);
   const adapter = new MeshWebRTCAdapter({
     signaling: client,
     peerId: localPeerId,
     knownPeerIds,
     RTCPeerConnection: FakePeerConnection as unknown as typeof RTCPeerConnection,
+    ...overrides,
   });
   return { adapter, sent };
 }
@@ -255,6 +275,123 @@ describe("MeshWebRTCAdapter peer-discovery dispatch", () => {
       adapter.handlePeerJoined("peer-b");
       await new Promise((r) => setTimeout(r, 0));
       expect(adapter.peerSlotCount()).toBe(2);
+    });
+  });
+
+  // ─── Polly issue #133 ──────────────────────────────────────────────────────
+  // A peer that reuses its peerId across short-lived sessions (a CLI
+  // `chat send` re-run from the same keyring is the canonical case)
+  // rejoins the signalling server under the same id. Before the fix, a
+  // slot left over from the peer's previous session wedged
+  // rediscovery: `evaluateInitiation`'s `slot-already-exists` gate
+  // refused the re-dial, so the survivor never reconnected until the
+  // idle watchdog reaped the corpse minutes later. handlePeerJoined /
+  // handlePeersPresent now treat the discovery frame as authoritative
+  // proof of a fresh signalling presence and evict a stale slot.
+  describe("stale-slot eviction on peer rejoin (polly#133)", () => {
+    const flush = () => new Promise((r) => setTimeout(r, 0));
+
+    test("evicts a dead slot and re-dials when the peer rejoins", async () => {
+      // peer-b > peer-a, so peer-b is the initiator toward peer-a.
+      const { adapter, sent } = buildAdapter("peer-b", ["peer-a"]);
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+      expect(sent).toHaveLength(1);
+      expect(adapter.peerSlotCount()).toBe(1);
+
+      // The peer's process exited; its connection died but the slot was
+      // never cleaned up (no `peer-left` reached us). Drive the fake
+      // connection into a terminal state to model the corpse.
+      const connection = FakePeerConnection.instances[0];
+      expect(connection).toBeDefined();
+      if (connection) connection.connectionState = "failed";
+
+      let disconnected = 0;
+      adapter.on("peer-disconnected", () => {
+        disconnected += 1;
+      });
+
+      // The same peerId rejoins the signalling roster.
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+
+      // The stale slot was torn down (one peer-disconnected emit) and a
+      // fresh offer fired against the reincarnated peer.
+      expect(disconnected).toBe(1);
+      expect(sent).toHaveLength(2);
+      expect(sent[1]?.targetPeerId).toBe("peer-a");
+      expect(adapter.peerSlotCount()).toBe(1);
+    });
+
+    test("keeps a live slot whose channel survived the peer's signalling reconnect", async () => {
+      const { adapter, sent } = buildAdapter("peer-b", ["peer-a"]);
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+      expect(sent).toHaveLength(1);
+
+      // The slot is fully established — connection `connected`, data
+      // channel `open`. A `peer-joined` here means the peer reconnected
+      // its signalling socket but kept the direct WebRTC session.
+      const connection = FakePeerConnection.instances[0];
+      expect(connection).toBeDefined();
+      if (connection) {
+        connection.connectionState = "connected";
+        if (connection.lastDataChannel) connection.lastDataChannel.readyState = "open";
+      }
+
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+
+      // The healthy slot is left intact — no teardown, no re-dial.
+      expect(sent).toHaveLength(1);
+      expect(adapter.peerSlotCount()).toBe(1);
+    });
+
+    test("leaves a young in-flight handshake alone on a duplicate frame", async () => {
+      // Default slotNeverConnectedTimeoutMs (30s): a slot created
+      // moments ago is still negotiating and must not be restarted.
+      const { adapter, sent } = buildAdapter("peer-b", ["peer-a"]);
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+      expect(sent).toHaveLength(1);
+      expect(adapter.peerSlotCount()).toBe(1);
+    });
+
+    test("evicts a slot stuck negotiating past the never-connected deadline", async () => {
+      // Tiny deadline so a slot that never leaves `new` counts as stale
+      // by the time the peer's next discovery frame arrives.
+      const { adapter, sent } = buildAdapter("peer-b", ["peer-a"], {
+        slotNeverConnectedTimeoutMs: 1,
+      });
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+      expect(sent).toHaveLength(1);
+
+      // Let the slot age past the 1ms deadline while still at `new`.
+      await new Promise((r) => setTimeout(r, 10));
+
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+      expect(sent).toHaveLength(2);
+      expect(adapter.peerSlotCount()).toBe(1);
+    });
+
+    test("handlePeersPresent also evicts a stale slot on a signalling reconnect", async () => {
+      const { adapter, sent } = buildAdapter("peer-b", ["peer-a"]);
+      adapter.handlePeerJoined("peer-a");
+      await flush();
+      expect(sent).toHaveLength(1);
+
+      const connection = FakePeerConnection.instances[0];
+      if (connection) connection.connectionState = "failed";
+
+      // A reconnected signalling client receives a fresh peers-present.
+      adapter.handlePeersPresent(["peer-a"]);
+      await flush();
+      expect(sent).toHaveLength(2);
+      expect(adapter.peerSlotCount()).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #133.

A surviving mesh peer could fail to reconnect to a peer that rejoins the signalling roster under a peerId an earlier session had already used. The survivor still held a `PeerSlot` from the peerId's previous incarnation, so `handlePeerJoined` hit `evaluateInitiation`'s `slot-already-exists` gate and declined to re-dial; `handleOffer`'s glare rule then made the lexicographically-higher survivor ignore the newcomer's offer too. The pair stayed apart until the idle-slot watchdog (`SLOT_IDLE_TIMEOUT_MS`, 120s) reaped the dead slot — far too late for the request that prompted the rejoin.

A CLI command re-run from the same keyring is the canonical trigger: `derivePeerId()` is a pure function of the keyring public key, so every `chat send` invocation reuses the same peerId. The "topology change" in #133 is coincidental — the failure is "second appearance of a reused peerId while a stale slot lingers", which the leader-lease repro first exercises after the failover.

## Fix

`handlePeerJoined` and `handlePeersPresent` now route through a new `evictStaleSlotForRejoin()`. A `peer-joined` / `peers-present` frame is authoritative proof the remote peer's signalling presence is fresh, so a slot held for that peerId is torn down before the dial path runs. The one shape kept is a data channel still `open` on a `connected` connection — the peer kept its direct WebRTC session across a signalling reconnect. A young, still-negotiating handshake (`new`/`connecting` within `slotNeverConnectedTimeoutMs`) is also left alone, so a duplicate frame cannot restart a connection that simply is not done yet.

## Not covered

Discovery still has no periodic roster resync — `peers-present` is one-shot per signalling connection and the sweep only re-dials peers already in `presentPeers`. A `peer-joined` genuinely *missed* for a short-lived peer remains unrecoverable. #133's `peers=0` symptom points at the stale-slot wedge, not a missed frame, so this fix addresses the reported failure; the resync gap is worth a separate ticket.

## Tests

- 5 new unit tests in `mesh-webrtc-adapter-peer-joined.test.ts`: dead slot evicted + re-dialled (single `peer-disconnected` emit), live slot kept, young handshake kept, slot stuck past the never-connected deadline evicted, `handlePeersPresent` evicting on a signalling reconnect.
- All 57 mesh adapter/diagnostics tests pass; biome and `tsc` clean.
- End-to-end verification is fairfox's `scripts/e2e-chat-leader-lease.ts` (real signalling server + werift + multi-process), which cannot run in this repo's CI. Once 0.74.1 is published, fairfox should un-defer that script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)