### PR TITLE
fix(verify): keep non-identifier message handlers (polly#144)

### DIFF
--- a/packages/polly/tools/analysis/src/extract/__tests__/handler-filtering-bug.test.ts
+++ b/packages/polly/tools/analysis/src/extract/__tests__/handler-filtering-bug.test.ts
@@ -84,14 +84,15 @@ export function routeMessage(msg: Message) {
     expect(analysis.messageTypes).not.toContain("{ ok: true; value: t }");
     expect(analysis.messageTypes).not.toContain("ok");
 
-    // **CRITICAL**: handlers array should also be filtered!
-    // This is what the bug was about - handlers with invalid message types
-    // were not filtered even though messageTypes was filtered
+    // **CRITICAL**: extraction-artifact handlers must still be dropped.
+    // polly#144 keeps representable non-identifier types (routes,
+    // colon-namespaced messages), but a leaked object-type text like
+    // "{ ok: true; value: t }" is not a real message type — it carries TS
+    // type-expression punctuation and must never reach the handlers array.
     for (const handler of analysis.handlers) {
-      // Every handler should have a valid TLA+ identifier as messageType
-      expect(handler.messageType).toMatch(
-        /^[a-zA-Z][a-zA-Z0-9_]*$/,
-        `Handler at ${handler.location.file}:${handler.location.line} has invalid messageType: "${handler.messageType}"`
+      expect(handler.messageType).not.toMatch(
+        /[{}();<>=]/,
+        `Handler at ${handler.location.file}:${handler.location.line} has extraction-artifact messageType: "${handler.messageType}"`
       );
     }
 
@@ -100,7 +101,7 @@ export function routeMessage(msg: Message) {
     expect(handlerTypes).toContain("query");
     expect(handlerTypes).toContain("command");
 
-    // Verify invalid handlers are NOT present
+    // Verify extraction-artifact handlers are NOT present
     expect(handlerTypes).not.toContain("{ ok: true; value: t }");
     expect(handlerTypes).not.toContain("ok");
     expect(handlerTypes).not.toContain("value");
@@ -164,7 +165,7 @@ function handleCommand(): Result<void> {
     }
   });
 
-  test("should filter handlers extracted via .on() with invalid types", async () => {
+  test("keeps colon-namespaced .on() handlers but drops object-literal artifacts", async () => {
     const tsConfigPath = path.join(tempDir, "tsconfig.json");
     fs.writeFileSync(
       tsConfigPath,
@@ -197,12 +198,12 @@ emitter.on('query', (data) => {
   console.log('query:', data);
 });
 
-// Invalid handler (contains special characters)
+// Colon-namespaced WS message — representable, kept (polly#144)
 emitter.on('user:login', (data) => {
   console.log('login:', data);
 });
 
-// Invalid handler (object literal syntax)
+// Object-literal artifact — carries TS type punctuation, must be dropped
 emitter.on('{ type: error }', (data) => {
   console.log('error:', data);
 });
@@ -211,18 +212,18 @@ emitter.on('{ type: error }', (data) => {
 
     const analysis = await analyzeCodebase({ tsConfigPath });
 
-    // Should only include handlers with valid TLA+ identifiers
     const handlerTypes = analysis.handlers.map((h) => h.messageType);
     expect(handlerTypes).toContain("authenticate");
     expect(handlerTypes).toContain("query");
 
-    // Should NOT include handlers with invalid identifiers
-    expect(handlerTypes).not.toContain("user:login");
+    // polly#144: colon-namespaced messages are representable and kept...
+    expect(handlerTypes).toContain("user:login");
+    // ...but object-literal extraction artifacts are still dropped.
     expect(handlerTypes).not.toContain("{ type: error }");
 
-    // All handlers must be valid
+    // No handler should carry TS type-expression punctuation
     for (const handler of analysis.handlers) {
-      expect(handler.messageType).toMatch(/^[a-zA-Z][a-zA-Z0-9_]*$/);
+      expect(handler.messageType).not.toMatch(/[{}();<>=]/);
     }
   });
 });

--- a/packages/polly/tools/analysis/src/extract/__tests__/tla-validation.test.ts
+++ b/packages/polly/tools/analysis/src/extract/__tests__/tla-validation.test.ts
@@ -147,7 +147,7 @@ export function handleMessage(msg: Message) {
     }
   });
 
-  test("should reject invalid TLA+ identifiers", async () => {
+  test("keeps representable non-identifier types, drops type-expression artifacts", async () => {
     // Create a tsconfig.json
     const tsConfigPath = path.join(tempDir, "tsconfig.json");
     fs.writeFileSync(
@@ -165,15 +165,17 @@ export function handleMessage(msg: Message) {
       })
     );
 
-    // Create a test file with invalid message types
+    // Create a test file mixing representable non-identifier types with a
+    // genuine type-expression artifact (polly#144).
     const testFile = path.join(tempDir, "invalid-messages.ts");
     fs.writeFileSync(
       testFile,
       `
-// These should be filtered out:
+// Representable, kept (emitted as quoted literals, sanitized into actions):
 // - Starting with digit: '123event'
 // - Containing special chars: 'event-type', 'event.type', 'event:type'
-// - Complex types: '{ ok: true }'
+// Dropped — TS type-expression artifact, not a real message type:
+// - '{ ok: true }'
 
 export interface Message {
   type: '123event' | 'event-type' | 'event.type' | 'event:type' | '{ ok: true }';
@@ -201,10 +203,12 @@ export function handleMessage(msg: Message) {
       tsConfigPath,
     });
 
-    // Check that invalid types are filtered out
-    const invalidTypes = ["123event", "event-type", "event.type", "event:type", "{ ok: true }"];
-    for (const invalidType of invalidTypes) {
-      expect(analysis.messageTypes).not.toContain(invalidType);
+    // polly#144: representable non-identifier types are kept...
+    const keptTypes = ["123event", "event-type", "event.type", "event:type"];
+    for (const keptType of keptTypes) {
+      expect(analysis.messageTypes).toContain(keptType);
     }
+    // ...but the type-expression artifact is dropped.
+    expect(analysis.messageTypes).not.toContain("{ ok: true }");
   });
 });

--- a/packages/polly/tools/analysis/src/extract/handlers.ts
+++ b/packages/polly/tools/analysis/src/extract/handlers.ts
@@ -253,7 +253,7 @@ export class HandlerExtractor {
 
           if (!exists) {
             handlers.push(handler);
-            if (this.isValidTLAIdentifier(handler.messageType)) {
+            if (this.canRepresentAsTLAAction(handler.messageType)) {
               messageTypes.add(handler.messageType);
             } else {
               invalidMessageTypes.add(handler.messageType);
@@ -418,7 +418,7 @@ export class HandlerExtractor {
       const syntheticHandlers = this.createResourceHandlers(resource, context);
       for (const handler of syntheticHandlers) {
         handlers.push(handler);
-        if (this.isValidTLAIdentifier(handler.messageType)) {
+        if (this.canRepresentAsTLAAction(handler.messageType)) {
           messageTypes.add(handler.messageType);
         } else {
           invalidMessageTypes.add(handler.messageType);
@@ -523,7 +523,7 @@ export class HandlerExtractor {
     invalidMessageTypes: Set<string>
   ): void {
     for (const handler of handlers) {
-      if (this.isValidTLAIdentifier(handler.messageType)) {
+      if (this.canRepresentAsTLAAction(handler.messageType)) {
         messageTypes.add(handler.messageType);
       } else {
         invalidMessageTypes.add(handler.messageType);
@@ -541,18 +541,16 @@ export class HandlerExtractor {
   }
 
   /**
-   * Check if a string is a valid TLA+ identifier
-   * TLA+ identifiers must:
-   * - Start with a letter (a-zA-Z)
-   * - Contain only letters, digits, and underscores
-   * - Not be empty
+   * Check whether a message type can be represented in the generated TLA+
+   * (polly#144). Message types become quoted string literals and are sanitized
+   * into `Handle…` action names, so HTTP routes ("POST /register/options") and
+   * colon-namespaced messages ("chat:send") are all representable — the only
+   * requirement is at least one letter to anchor the action name. Strings
+   * carrying TS type-expression punctuation (`{}();<>=`) are rejected as
+   * extraction artifacts rather than real message types.
    */
-  private isValidTLAIdentifier(s: string): boolean {
-    if (!s || s.length === 0) {
-      return false;
-    }
-    // TLA+ identifiers: start with letter, contain only alphanumeric + underscore
-    return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(s);
+  private canRepresentAsTLAAction(s: string): boolean {
+    return typeof s === "string" && /[a-zA-Z]/.test(s) && !/[{}();<>=]/.test(s);
   }
 
   /**

--- a/packages/polly/tools/analysis/src/extract/types.ts
+++ b/packages/polly/tools/analysis/src/extract/types.ts
@@ -73,67 +73,79 @@ export class TypeExtractor {
   }
 
   /**
-   * Filter and log message types, keeping only valid TLA+ identifiers
+   * Filter and log message types, keeping every type that can be represented
+   * in TLA+ (polly#144). A message type is only ever emitted as a *quoted*
+   * string literal ("POST /register/options") and turned into an action name
+   * via sanitization, so non-identifier types like HTTP routes and
+   * colon-namespaced WS messages are perfectly representable. We drop only the
+   * genuinely unrepresentable ones — strings with no letter to anchor an action
+   * name (empty, whitespace, all-symbol).
    */
   private filterAndLogMessageTypes(
     messageTypes: string[],
     handlerMessageTypes: Set<string>
   ): string[] {
     const allMessageTypes = Array.from(new Set([...messageTypes, ...handlerMessageTypes]));
-    const validMessageTypes: string[] = [];
-    const invalidMessageTypes: string[] = [];
+    const keptMessageTypes: string[] = [];
+    const droppedMessageTypes: string[] = [];
 
     for (const msgType of allMessageTypes) {
-      if (this.isValidTLAIdentifier(msgType)) {
-        validMessageTypes.push(msgType);
+      if (this.canRepresentAsTLAAction(msgType)) {
+        keptMessageTypes.push(msgType);
       } else {
-        invalidMessageTypes.push(msgType);
+        droppedMessageTypes.push(msgType);
       }
     }
 
-    this.logInvalidMessageTypes(invalidMessageTypes);
-    return validMessageTypes;
+    this.logDroppedMessageTypes(droppedMessageTypes);
+    return keptMessageTypes;
   }
 
   /**
-   * Log warnings about invalid message types
+   * Log warnings about unrepresentable message types. Unlike the old
+   * invalid-identifier path this is unconditional (not POLLY_DEBUG-gated):
+   * silently dropping handlers was the core failure mode in polly#144.
    */
-  private logInvalidMessageTypes(invalidMessageTypes: string[]): void {
-    if (invalidMessageTypes.length === 0 || !process.env["POLLY_DEBUG"]) return;
+  private logDroppedMessageTypes(droppedMessageTypes: string[]): void {
+    if (droppedMessageTypes.length === 0) return;
 
-    console.log(`[WARN] Filtered out ${invalidMessageTypes.length} invalid message type(s):`);
-    for (const invalid of invalidMessageTypes) {
-      console.log(`[WARN]   - "${invalid}" (not a valid TLA+ identifier)`);
+    console.log(
+      `[WARN] Dropped ${droppedMessageTypes.length} unrepresentable message type(s) (no letter to form a TLA+ action name):`
+    );
+    for (const dropped of droppedMessageTypes) {
+      console.log(`[WARN]   - "${dropped}"`);
     }
   }
 
   /**
-   * Filter and log handlers, keeping only those with valid TLA+ identifier message types
+   * Filter and log handlers, keeping every handler whose message type is
+   * representable in TLA+ (polly#144 — HTTP routes and colon-namespaced
+   * messages included).
    */
   private filterAndLogHandlers(
     handlers: Array<{ messageType: string; location: { file: string; line: number } }>
   ) {
-    const validHandlers = handlers.filter((h) => this.isValidTLAIdentifier(h.messageType));
+    const keptHandlers = handlers.filter((h) => this.canRepresentAsTLAAction(h.messageType));
 
-    this.logInvalidHandlers(handlers, validHandlers);
-    return validHandlers;
+    this.logDroppedHandlers(handlers, keptHandlers);
+    return keptHandlers;
   }
 
   /**
-   * Log warnings about filtered handlers
+   * Log warnings about dropped handlers (unconditional — see polly#144).
    */
-  private logInvalidHandlers(
+  private logDroppedHandlers(
     allHandlers: Array<{ messageType: string; location: { file: string; line: number } }>,
-    validHandlers: Array<{ messageType: string }>
+    keptHandlers: Array<{ messageType: string }>
   ): void {
-    const filteredHandlerCount = allHandlers.length - validHandlers.length;
-    if (filteredHandlerCount === 0 || !process.env["POLLY_DEBUG"]) return;
+    const droppedHandlerCount = allHandlers.length - keptHandlers.length;
+    if (droppedHandlerCount === 0) return;
 
     console.log(
-      `[WARN] Filtered out ${filteredHandlerCount} handler(s) with invalid message types:`
+      `[WARN] Dropped ${droppedHandlerCount} handler(s) with unrepresentable message types:`
     );
     for (const handler of allHandlers) {
-      if (!this.isValidTLAIdentifier(handler.messageType)) {
+      if (!this.canRepresentAsTLAAction(handler.messageType)) {
         console.log(
           `[WARN]   - Handler for "${handler.messageType}" at ${handler.location.file}:${handler.location.line}`
         );
@@ -142,18 +154,16 @@ export class TypeExtractor {
   }
 
   /**
-   * Check if a string is a valid TLA+ identifier
-   * TLA+ identifiers must:
-   * - Start with a letter (a-zA-Z)
-   * - Contain only letters, digits, and underscores
-   * - Not be empty
+   * Check whether a message type can be represented in the generated TLA+
+   * (polly#144). The type itself becomes a quoted string literal, so the only
+   * hard requirement is that it contains at least one letter — enough to
+   * sanitize into a valid `Handle…` action name. Everything else (slashes,
+   * colons, spaces, leading digits) is fine. Strings carrying TS
+   * type-expression punctuation (`{}();<>=`) are rejected as extraction
+   * artifacts rather than real message types.
    */
-  private isValidTLAIdentifier(s: string): boolean {
-    if (!s || s.length === 0) {
-      return false;
-    }
-    // TLA+ identifiers: start with letter, contain only alphanumeric + underscore
-    return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(s);
+  private canRepresentAsTLAAction(s: string): boolean {
+    return typeof s === "string" && /[a-zA-Z]/.test(s) && !/[{}();<>=]/.test(s);
   }
 
   /**

--- a/packages/polly/tools/verify/src/__tests__/codegen/http-route-handlers.test.ts
+++ b/packages/polly/tools/verify/src/__tests__/codegen/http-route-handlers.test.ts
@@ -1,0 +1,163 @@
+// Regression tests for polly#144 — the TLA+ generator used to silently drop
+// every handler whose messageType wasn't a bare TLA+ identifier (HTTP routes
+// like "POST /register/options", colon-namespaced WS messages like "chat:send"),
+// emitting a "No message handlers found" stub and reporting a passing run with
+// zero verified postconditions. These handlers are now kept: the messageType
+// becomes a quoted TLA+ string literal and the action name is sanitized.
+
+import { describe, expect, test } from "bun:test";
+import type { CodebaseAnalysis } from "../../../../analysis/src/types";
+import { RoundTripValidator } from "../../codegen/round-trip";
+import { generateSubsystemTLA, TLAGenerator } from "../../codegen/tla";
+import type { VerificationConfig } from "../../types";
+
+const config: VerificationConfig = {
+  state: { authPhase: { type: "enum", values: ["anonymous", "authenticated"] } },
+  messages: { maxInFlight: 1, maxTabs: 1 },
+  onBuild: "warn",
+  onRelease: "error",
+};
+
+function analysisWith(
+  handlers: Array<{
+    messageType: string;
+    postconditions?: Array<{ expression: string; message?: string }>;
+  }>
+): CodebaseAnalysis {
+  return {
+    stateType: null,
+    messageTypes: handlers.map((h) => h.messageType),
+    fields: [],
+    handlers: handlers.map((h) => ({
+      messageType: h.messageType,
+      node: "background" as const,
+      assignments: [],
+      preconditions: [],
+      postconditions: h.postconditions ?? [],
+      location: { file: "server.ts", line: 1 },
+    })),
+  };
+}
+
+describe("polly#144: non-identifier message handlers reach TLC", () => {
+  test("HTTP routes and colon-namespaced messages survive codegen", async () => {
+    const analysis = analysisWith([
+      { messageType: "POST /register/options" },
+      {
+        messageType: "POST /login/verify",
+        postconditions: [
+          { expression: 'authMachine.value.phase === "authenticated"', message: "logged in" },
+        ],
+      },
+      { messageType: "chat:send" },
+      { messageType: "GET /me" },
+    ]);
+
+    const { spec } = await new TLAGenerator().generate(config, analysis);
+
+    // No silent stub — the whole point of the bug.
+    expect(spec).not.toContain("No message handlers found");
+    expect(spec).not.toContain("No valid message handlers");
+
+    // Message types appear as quoted TLA+ string literals (legal for any chars).
+    expect(spec).toContain('"POST /register/options"');
+    expect(spec).toContain('"chat:send"');
+    expect(spec).toContain('"GET /me"');
+
+    // Action names are sanitized into valid TLA+ identifiers.
+    expect(spec).toContain("HandlePostRegisterOptions(ctx) ==");
+    expect(spec).toContain("HandlePostLoginVerify(ctx) ==");
+    expect(spec).toContain("HandleChatSend(ctx) ==");
+    expect(spec).toContain("HandleGetMe(ctx) ==");
+
+    // The dispatcher routes the quoted messageType to its sanitized action.
+    expect(spec).toContain('IF msgType = "POST /register/options" THEN HandlePostRegisterOptions');
+
+    // The route's ensures(...) becomes a real EnsuresAfter step-property.
+    expect(spec).toContain("EnsuresAfter_HandlePostLoginVerify");
+  });
+
+  test("ensures count is non-zero for anchored route handlers", async () => {
+    const analysis = analysisWith([
+      {
+        messageType: "POST /logout",
+        postconditions: [{ expression: 'authMachine.value.phase === "anonymous"' }],
+      },
+    ]);
+
+    const { spec } = await new TLAGenerator().generate(config, analysis);
+    // Mirrors the cli.ts count of registered postcondition properties.
+    const ensuresCount = (spec.match(/^EnsuresAfter_\w+ ==/gm) ?? []).length;
+    expect(ensuresCount).toBeGreaterThan(0);
+  });
+
+  test("distinct messageTypes that sanitize alike get distinct action names", async () => {
+    const analysis = analysisWith([
+      { messageType: "task:tree-cloned" },
+      { messageType: "task/tree/cloned" },
+    ]);
+
+    const { spec } = await new TLAGenerator().generate(config, analysis);
+    const actions = (spec.match(/^Handle\w+\(ctx\) ==/gm) ?? []).map((l) =>
+      l.replace("(ctx) ==", "")
+    );
+    // Both handlers keep a definition; the collision is broken with a suffix.
+    expect(actions).toContain("HandleTaskTreeCloned");
+    expect(actions).toContain("HandleTaskTreeCloned_2");
+    expect(new Set(actions).size).toBe(actions.length); // all unique
+  });
+
+  test("validateInputs keeps representable types, rejects only artifacts", async () => {
+    // Representable: must not throw.
+    await new TLAGenerator().generate(config, analysisWith([{ messageType: "POST /x" }]));
+
+    // Unrepresentable (no letter): must throw.
+    await expect(
+      new TLAGenerator().generate(config, analysisWith([{ messageType: "///" }]))
+    ).rejects.toThrow(/[Uu]nrepresentable/);
+  });
+
+  test("subsystem path (the issue's repro) registers real ensures properties", async () => {
+    // Reproduces the #144 report: a subsystem whose `handlers` list is made up
+    // entirely of HTTP routes. It used to generate the no-handlers stub and
+    // report 0 ensures next to a passing tick.
+    const authSubsystem = {
+      state: ["authPhase"],
+      handlers: ["POST /login/verify", "POST /logout"],
+    };
+    const subsystemConfig: VerificationConfig = {
+      ...config,
+      messages: { maxInFlight: 2, maxTabs: 1 },
+      subsystems: { auth: authSubsystem },
+    };
+    const analysis = analysisWith([
+      {
+        messageType: "POST /login/verify",
+        postconditions: [{ expression: 'authMachine.value.phase === "authenticated"' }],
+      },
+      {
+        messageType: "POST /logout",
+        postconditions: [{ expression: 'authMachine.value.phase === "anonymous"' }],
+      },
+    ]);
+
+    const { spec } = await generateSubsystemTLA("auth", authSubsystem, subsystemConfig, analysis);
+
+    expect(spec).not.toContain("No message handlers found");
+    expect(spec).toContain('UserMessageTypes == {"POST /login/verify", "POST /logout"}');
+    const ensuresCount = (spec.match(/^EnsuresAfter_\w+ ==/gm) ?? []).length;
+    expect(ensuresCount).toBe(2);
+  });
+
+  test("route message types round-trip back out of the generated spec", async () => {
+    const analysis = analysisWith([
+      { messageType: "POST /register/options" },
+      { messageType: "chat:send" },
+    ]);
+    const { spec } = await new TLAGenerator().generate(config, analysis);
+
+    const result = await new RoundTripValidator().validate(config, analysis, spec);
+    expect(result.extracted.messageTypes).toContain("POST /register/options");
+    expect(result.extracted.messageTypes).toContain("chat:send");
+  });
+});

--- a/packages/polly/tools/verify/src/codegen/tla.ts
+++ b/packages/polly/tools/verify/src/codegen/tla.ts
@@ -113,6 +113,23 @@ export class TLAGenerator {
   }
 
   /**
+   * Check whether a message type can be represented in the generated TLA+
+   * (polly#144). A message type is only ever emitted as a quoted string literal
+   * (legal TLA+ for any characters) and sanitized into a `Handle…` action name,
+   * so the sole requirement is that it carries at least one letter to anchor
+   * that action name. HTTP routes ("POST /register/options") and
+   * colon-namespaced messages ("chat:send") all qualify; only empty,
+   * whitespace, or all-symbol strings are genuinely unrepresentable.
+   *
+   * We also reject strings carrying TS type-expression punctuation
+   * (`{}();<>=`) — those are extraction artifacts (e.g. a leaked object-type
+   * text like "{ ok: true; value: t }"), not real message types.
+   */
+  private canRepresentAsTLAAction(s: string): boolean {
+    return typeof s === "string" && /[a-zA-Z]/.test(s) && !/[{}();<>=]/.test(s);
+  }
+
+  /**
    * Generate TLA+ specification with optional validation
    *
    * If validators were provided in constructor, this method will:
@@ -321,11 +338,14 @@ export class TLAGenerator {
    * Pre-validate inputs before generation
    */
   private validateInputs(_config: VerificationConfig, analysis: CodebaseAnalysis): void {
-    // Validate message types are valid TLA+ identifiers
+    // polly#144: message types are emitted as quoted string literals and
+    // sanitized into action names, so non-identifier types (HTTP routes,
+    // colon-namespaced messages) are valid. Reject only the genuinely
+    // unrepresentable ones — strings with no letter to form an action name.
     for (const messageType of analysis.messageTypes) {
-      if (!this.isValidTLAIdentifier(messageType)) {
+      if (!this.canRepresentAsTLAAction(messageType)) {
         throw new Error(
-          `Invalid message type '${messageType}'. TLA+ identifiers must start with a letter and contain only letters, digits, and underscores.`
+          `Unrepresentable message type '${messageType}'. A message type must contain at least one letter so it can be sanitized into a TLA+ action name.`
         );
       }
     }
@@ -994,25 +1014,28 @@ export class TLAGenerator {
       console.log("[DEBUG] [TLAGenerator] analysis.messageTypes:", analysis.messageTypes);
     }
 
-    // Filter out invalid TLA+ identifiers
+    // polly#144: keep every representable message type. The type is emitted
+    // below as a quoted string literal (TLA-safe for routes/colon names) and
+    // sanitized into an action name elsewhere; only drop the unrepresentable
+    // ones (no letter to anchor an action name).
     let validMessageTypes: string[] = [];
     const invalidMessageTypes: string[] = [];
 
     for (const msgType of analysis.messageTypes) {
-      if (this.isValidTLAIdentifier(msgType)) {
+      if (this.canRepresentAsTLAAction(msgType)) {
         validMessageTypes.push(msgType);
       } else {
         invalidMessageTypes.push(msgType);
       }
     }
 
-    // Log warnings about invalid message types
+    // Log warnings about unrepresentable message types
     if (invalidMessageTypes.length > 0 && process.env["POLLY_DEBUG"]) {
       console.log(
-        `[WARN] [TLAGenerator] Filtered out ${invalidMessageTypes.length} invalid message type(s):`
+        `[WARN] [TLAGenerator] Dropped ${invalidMessageTypes.length} unrepresentable message type(s):`
       );
       for (const invalid of invalidMessageTypes) {
-        console.log(`[WARN]   - "${invalid}" (not a valid TLA+ identifier)`);
+        console.log(`[WARN]   - "${invalid}" (no letter to form a TLA+ action name)`);
       }
     }
 
@@ -1640,7 +1663,10 @@ export class TLAGenerator {
   }
 
   /**
-   * Filter handlers into valid and invalid based on TLA+ identifier rules
+   * Partition handlers by whether their message type is representable in TLA+
+   * (polly#144). Representable handlers — including HTTP routes and
+   * colon-namespaced messages — keep their full pre/post/assignment work;
+   * only genuinely unrepresentable ones (no letter) are set aside.
    */
   private filterHandlersByValidity(handlers: MessageHandler[]): {
     validHandlers: MessageHandler[];
@@ -1650,7 +1676,7 @@ export class TLAGenerator {
     const invalidHandlers: MessageHandler[] = [];
 
     for (const handler of handlers) {
-      if (this.isValidTLAIdentifier(handler.messageType)) {
+      if (this.canRepresentAsTLAAction(handler.messageType)) {
         validHandlers.push(handler);
       } else {
         invalidHandlers.push(handler);
@@ -1661,13 +1687,13 @@ export class TLAGenerator {
   }
 
   /**
-   * Log warnings about invalid handlers
+   * Log warnings about unrepresentable handlers
    */
   private logInvalidHandlers(invalidHandlers: MessageHandler[]): void {
     if (invalidHandlers.length === 0 || !process.env["POLLY_DEBUG"]) return;
 
     console.log(
-      `[WARN] [TLAGenerator] Filtered out ${invalidHandlers.length} handler(s) with invalid message types:`
+      `[WARN] [TLAGenerator] Dropped ${invalidHandlers.length} handler(s) with unrepresentable message types:`
     );
     for (const handler of invalidHandlers) {
       console.log(
@@ -3064,22 +3090,49 @@ export class TLAGenerator {
     >
   ): void {
     for (const [baseActionName, messageTypes] of actionNameToMessageTypes.entries()) {
-      if (messageTypes.length === 1) {
-        const entry = messageTypes[0];
-        if (entry) {
-          this.resolvedActionNames.set(entry.messageType, baseActionName);
-        }
+      const single = messageTypes.length === 1 ? messageTypes[0] : undefined;
+      if (single) {
+        this.resolvedActionNames.set(single.messageType, baseActionName);
         continue;
       }
-      // Collision detected - use origin to differentiate
-      for (const entry of messageTypes) {
-        const resolvedName =
-          entry.origin === "stateHandler"
-            ? baseActionName.replace(/^Handle/, "HandleFn")
-            : baseActionName;
-        this.resolvedActionNames.set(entry.messageType, resolvedName);
-      }
+      this.resolveCollidingGroup(baseActionName, messageTypes);
     }
+  }
+
+  /**
+   * Resolve a group of message types that share a base action name. Origin
+   * differentiates event vs stateHandler; polly#144 then appends a
+   * deterministic numeric suffix so distinct message types that sanitize to
+   * the same name (e.g. "task:tree-cloned" and "task/tree/cloned") never
+   * collapse onto one action.
+   */
+  private resolveCollidingGroup(
+    baseActionName: string,
+    messageTypes: Array<{ messageType: string; origin?: "event" | "stateHandler" }>
+  ): void {
+    const usedNames = new Set<string>();
+    for (const entry of messageTypes) {
+      const originName =
+        entry.origin === "stateHandler"
+          ? baseActionName.replace(/^Handle/, "HandleFn")
+          : baseActionName;
+      this.resolvedActionNames.set(entry.messageType, this.uniquify(originName, usedNames));
+    }
+  }
+
+  /**
+   * Return `name`, or `name_N` for the smallest N >= 2 not already in `used`,
+   * recording the result in `used`.
+   */
+  private uniquify(name: string, used: Set<string>): string {
+    let candidate = name;
+    let suffix = 2;
+    while (used.has(candidate)) {
+      candidate = `${name}_${suffix}`;
+      suffix++;
+    }
+    used.add(candidate);
+    return candidate;
   }
 
   /**
@@ -3271,9 +3324,10 @@ export class TLAGenerator {
     this.line("UserNext ==");
     this.indent++;
 
-    // Check if there are any valid handlers (not just any handlers)
+    // Check if there are any representable handlers (polly#144 — routes and
+    // colon-namespaced messages count, not just bare TLA+ identifiers).
     const hasValidHandlers = analysis.handlers.some((h) =>
-      this.isValidTLAIdentifier(h.messageType)
+      this.canRepresentAsTLAAction(h.messageType)
     );
 
     if (hasValidHandlers) {


### PR DESCRIPTION
## Summary

The TLA+ generator silently dropped every handler whose `messageType` was not a bare TLA+ identifier — HTTP routes (`POST /register/options`), colon-namespaced WS messages (`chat:send`). With all such handlers gone, `addActions` emitted the `No message handlers found` stub, TLC explored an empty state machine, reported PASS, and registered **zero** ensures. From the caller's side the run looked successful; nothing surfaced that every anchored `requires`/`ensures`/state-assignment had been discarded before reaching TLC.

The filter was never necessary: a message type is only ever emitted as a *quoted* TLA+ string literal (legal for any characters), and the action name is already sanitized by `messageTypeToActionName` (`POST /register/options` → `HandlePostRegisterOptions`).

Closes #144.

## What changed

Non-identifier message types were dropped at three points, all keyed on the over-strict `isValidTLAIdentifier`. Each is replaced with a `canRepresentAsTLAAction` check:

- **`analysis/.../extract/handlers.ts`** — handler-type categorization no longer routes routes/colon names into `invalidMessageTypes`.
- **`analysis/.../extract/types.ts`** — `filterAndLog*` keep representable types/handlers; dropped ones are now logged **unconditionally** (was `POLLY_DEBUG`-gated — silent dropping was the core complaint).
- **`verify/.../codegen/tla.ts`** — `validateInputs` throws only on unrepresentable types; `addMessageTypes`, `filterHandlersByValidity`, and `addNext` keep representable handlers.

Representability = carries at least one letter (to anchor an action name) and no TS type-expression punctuation (`{}();<>=`), so genuine extraction artifacts like a leaked `{ ok: true; value: t }` are still dropped.

Collision resolution is hardened (`resolveCollidingGroup` + `uniquify`): two distinct types that sanitize to the same action name (`task:tree-cloned` vs `task/tree/cloned`) now get distinct definitions (`…`, `…_2`) instead of one silently overwriting the other.

## Effect

A subsystem whose handlers are all HTTP routes now generates `UserMessageTypes == {"POST /login/verify", "POST /logout"}`, sanitized `Handle*` actions, and real `EnsuresAfter_*` step-properties — the per-subsystem ensures count is a real signal again.

## Tests

- New `verify/src/__tests__/codegen/http-route-handlers.test.ts`: codegen survival, non-zero ensures count, collision uniqueness, `validateInputs` boundary, the subsystem repro from the issue, and round-trip.
- Updated the now-incorrect extraction assertions in `handler-filtering-bug.test.ts` and `tla-validation.test.ts` (colon-namespaced types kept; object-literal artifacts still dropped).

verify suite 771/771, analysis suite 86/86, `tsc --noEmit` clean, biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)