### PR TITLE
fix(verify): translate arithmetic RHS in object-literal signal updates (polly#147)

### DIFF
--- a/packages/polly/tools/analysis/src/extract/__tests__/handler-object-literal-arithmetic.test.ts
+++ b/packages/polly/tools/analysis/src/extract/__tests__/handler-object-literal-arithmetic.test.ts
@@ -1,0 +1,143 @@
+// polly#147 — object-literal signal updates with a non-literal RHS used to be
+// silently dropped: `extractValue` only handled literals, so a counter like
+// `sessions.value = { outstanding: sessions.value.outstanding + 1 }` produced
+// no assignment and the generated action was an UNCHANGED stub. The extractor
+// now captures any translatable expression initializer as an `EXPR:` marker,
+// mirroring how `state.foo += 1` keeps its RHS, so codegen can translate it.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { HandlerExtractor } from "../handlers";
+
+describe("HandlerExtractor — object-literal arithmetic RHS (polly#147)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "polly-147-test-"));
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  function createTsConfig(): string {
+    const tsConfigPath = path.join(tempDir, "tsconfig.json");
+    fs.writeFileSync(
+      tsConfigPath,
+      JSON.stringify({
+        compilerOptions: { target: "ES2020", module: "ESNext", strict: true },
+        include: ["*.ts"],
+      })
+    );
+    fs.writeFileSync(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ name: "test-pkg", version: "0.0.1" })
+    );
+    return tsConfigPath;
+  }
+
+  function extract(body: string) {
+    fs.writeFileSync(
+      path.join(tempDir, "handlers.ts"),
+      `
+type Signal<T> = { value: T };
+declare function $sharedState<T>(name: string, initial: T): Signal<T>;
+declare const bus: {
+  on: <T>(type: string, fn: (payload: T) => void) => void;
+};
+
+const sessions = $sharedState("sessions", { outstanding: 0 });
+const other = $sharedState("other", { count: 0 });
+
+${body}
+`
+    );
+    return new HandlerExtractor(createTsConfig()).extractHandlers();
+  }
+
+  test("mint: `{ outstanding: sessions.value.outstanding + 1 }` is captured as an EXPR", () => {
+    const result = extract(`
+bus.on("MINT", () => {
+  sessions.value = { outstanding: sessions.value.outstanding + 1 };
+});
+`);
+    const handler = result.handlers.find((h) => h.messageType === "MINT");
+    expect(handler).toBeDefined();
+    expect(handler!.assignments).toEqual(
+      expect.arrayContaining([
+        { field: "sessions_outstanding", value: "EXPR:sessions.value.outstanding + 1" },
+      ])
+    );
+  });
+
+  test("revoke: subtraction RHS is captured", () => {
+    const result = extract(`
+bus.on("REVOKE", () => {
+  sessions.value = { outstanding: sessions.value.outstanding - 1 };
+});
+`);
+    const handler = result.handlers.find((h) => h.messageType === "REVOKE");
+    expect(handler!.assignments).toEqual(
+      expect.arrayContaining([
+        { field: "sessions_outstanding", value: "EXPR:sessions.value.outstanding - 1" },
+      ])
+    );
+  });
+
+  test("spread + arithmetic: the spread is ignored, the arithmetic field captured", () => {
+    const result = extract(`
+bus.on("MINT_SPREAD", () => {
+  sessions.value = { ...sessions.value, outstanding: sessions.value.outstanding + 1 };
+});
+`);
+    const handler = result.handlers.find((h) => h.messageType === "MINT_SPREAD");
+    expect(handler!.assignments).toEqual(
+      expect.arrayContaining([
+        { field: "sessions_outstanding", value: "EXPR:sessions.value.outstanding + 1" },
+      ])
+    );
+  });
+
+  test("plain copy of another field is captured as an EXPR", () => {
+    const result = extract(`
+bus.on("COPY", () => {
+  sessions.value = { outstanding: other.value.count };
+});
+`);
+    const handler = result.handlers.find((h) => h.messageType === "COPY");
+    expect(handler!.assignments).toEqual(
+      expect.arrayContaining([{ field: "sessions_outstanding", value: "EXPR:other.value.count" }])
+    );
+  });
+
+  test("literal RHS is still captured as a plain value (unchanged behaviour)", () => {
+    const result = extract(`
+bus.on("RESET", () => {
+  sessions.value = { outstanding: 0 };
+});
+`);
+    const handler = result.handlers.find((h) => h.messageType === "RESET");
+    expect(handler!.assignments).toEqual(
+      expect.arrayContaining([{ field: "sessions_outstanding", value: 0 }])
+    );
+  });
+
+  test("payload-parameter RHS still produces a param: marker, not an EXPR", () => {
+    const result = extract(`
+bus.on<{ n: number }>("SET", (payload) => {
+  sessions.value = { outstanding: payload.n };
+});
+`);
+    const handler = result.handlers.find((h) => h.messageType === "SET");
+    expect(handler!.assignments).toEqual(
+      expect.arrayContaining([{ field: "sessions_outstanding", value: "param:n" }])
+    );
+    // ...and definitely not doubly-captured as an expression.
+    const outstanding = handler!.assignments.filter((a) => a.field === "sessions_outstanding");
+    expect(outstanding).toHaveLength(1);
+  });
+});

--- a/packages/polly/tools/analysis/src/extract/handlers.ts
+++ b/packages/polly/tools/analysis/src/extract/handlers.ts
@@ -1685,7 +1685,48 @@ export class HandlerExtractor {
     const paramName = this.extractPayloadPropertyParam(initializer);
     if (paramName !== null) {
       assignments.push({ field, value: `param:${paramName}` });
+      return;
     }
+
+    // polly#147: a non-literal initializer that is a translatable expression —
+    // arithmetic on the signal's own field (`outstanding + 1`), a copy of
+    // another field, an index access — is captured verbatim and translated to
+    // TLA+ at codegen time, mirroring how `state.foo += 1` keeps its RHS via
+    // `right.getText()`. Without this the assignment was silently dropped, so a
+    // counter `signal.value = { outstanding: signal.value.outstanding + 1 }`
+    // generated an UNCHANGED stub and its bounded-counter ensures could never
+    // be anchored.
+    if (this.isTranslatableInitializer(initializer)) {
+      assignments.push({ field, value: `EXPR:${initializer.getText()}` });
+      return;
+    }
+
+    if (process.env["POLLY_DEBUG"]) {
+      const on = signalName ? ` on ${signalName}.value` : "";
+      console.log(
+        `[WARN] dropped object-literal property '${name}'${on} — initializer kind ${initializer.getKindName()} is not translatable to TLA+`
+      );
+    }
+  }
+
+  /**
+   * Whether an object-literal property initializer is an expression the codegen
+   * translator (`tsExpressionToTLA`) handles reliably (polly#147). Literals and
+   * payload-parameter references are resolved before this is reached; this
+   * covers arithmetic, member/index access, and (un)parenthesized unary forms.
+   * Call and conditional expressions are deliberately excluded — they translate
+   * unreliably and would risk emitting invalid TLA+ rather than being caught
+   * here and surfaced as a warning.
+   */
+  private isTranslatableInitializer(node: Node): boolean {
+    return (
+      Node.isBinaryExpression(node) ||
+      Node.isPropertyAccessExpression(node) ||
+      Node.isElementAccessExpression(node) ||
+      Node.isPrefixUnaryExpression(node) ||
+      Node.isPostfixUnaryExpression(node) ||
+      Node.isParenthesizedExpression(node)
+    );
   }
 
   /**

--- a/packages/polly/tools/verify/src/__tests__/codegen/object-literal-arithmetic.test.ts
+++ b/packages/polly/tools/verify/src/__tests__/codegen/object-literal-arithmetic.test.ts
@@ -1,0 +1,78 @@
+// polly#147 — integration test across the documented pipeline
+// (analyzeCodebase → generateTLA). A counter updated through an object-literal
+// signal write with an arithmetic RHS used to extract no assignment, so the
+// generated action was an `UNCHANGED contextStates` stub and the bounded-
+// counter ensures could never be satisfied — TLC reported a real-looking
+// violation that was really an extractor gap. This proves the two halves
+// compose: the EXPR assignment survives extraction AND becomes a real EXCEPT.
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { analyzeCodebase } from "../../../../analysis/src/extract/types";
+import { generateTLA } from "../../codegen/tla";
+import type { VerificationConfig } from "../../types";
+
+function writeProject(dir: string, handlerBody: string): string {
+  const tsConfigPath = path.join(dir, "tsconfig.json");
+  fs.writeFileSync(
+    tsConfigPath,
+    JSON.stringify({
+      compilerOptions: { target: "ES2020", module: "ESNext", strict: true },
+      include: ["*.ts"],
+    })
+  );
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "p", version: "0.0.1" }));
+  fs.writeFileSync(
+    path.join(dir, "handlers.ts"),
+    `
+type Signal<T> = { value: T };
+declare function $sharedState<T>(name: string, initial: T): Signal<T>;
+declare const bus: { on: <T>(type: string, fn: (payload: T) => void) => void };
+
+const sessions = $sharedState("sessions", { outstanding: 0 });
+
+${handlerBody}
+`
+  );
+  return tsConfigPath;
+}
+
+describe("polly#147: object-literal arithmetic survives the full pipeline", () => {
+  test("a mint counter generates a real EXCEPT, not an UNCHANGED stub", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "polly-147-int-"));
+    try {
+      const tsConfigPath = writeProject(
+        dir,
+        `
+bus.on("MINT", () => {
+  sessions.value = { outstanding: sessions.value.outstanding + 1 };
+});
+`
+      );
+
+      const analysis = await analyzeCodebase({ tsConfigPath });
+      const config: VerificationConfig = {
+        state: { sessions: { outstanding: { min: 0, max: 2 } } },
+        messages: { maxInFlight: 1, maxTabs: 1 },
+        onBuild: "warn",
+        onRelease: "error",
+      };
+
+      const { spec } = await generateTLA(config, analysis);
+
+      // The handler action must EXCEPT-update the counter with arithmetic...
+      expect(spec).toContain(
+        "![ctx].sessions_outstanding = contextStates[ctx].sessions_outstanding + 1"
+      );
+
+      // ...and must NOT be the dropped-assignment stub.
+      const action = spec.slice(spec.indexOf("HandleMint(ctx) =="));
+      const nextHandler = action.indexOf("\n\n");
+      expect(action.slice(0, nextHandler)).not.toContain("UNCHANGED contextStates");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/polly/tools/verify/src/codegen/tla.ts
+++ b/packages/polly/tools/verify/src/codegen/tla.ts
@@ -3171,6 +3171,14 @@ export class TLAGenerator {
         const paramName = value.substring(6);
         return `payload.${this.sanitizeFieldName(paramName)}`;
       }
+      // polly#147: a captured object-literal expression RHS (e.g.
+      // "sessionsMachine.value.outstanding + 1"). Translate it like a
+      // requires/ensures expression — signal references flatten to
+      // contextStates[ctx].<field> (pre-state, unprimed, valid inside the
+      // EXCEPT clause), arithmetic and operators pass through.
+      if (value.startsWith("EXPR:")) {
+        return this.tsExpressionToTLA(value.substring(5), false);
+      }
       // Check if this is already a TLA+ expression (compound operator or array mutation)
       // These contain @ (current value reference) or TLA+ operators
       if (this.isTLAExpression(value)) {


### PR DESCRIPTION
## Summary

A signal update written as an object literal — `signal.value = { foo: <expr> }` — ran its property initializers through `extractValue`, which only handles literals. Any non-literal RHS (a `BinaryExpression`, property access, index access) returned `undefined`, and `extractRegularPropertyAssignment` bailed without pushing an assignment. The state update silently disappeared and the generated action became an `UNCHANGED contextStates` stub.

The canonical mint/revoke counter:

```ts
sessionsMachine.value = { outstanding: sessionsMachine.value.outstanding + 1 };
```

left `outstanding` pinned at 0, so a `>= 1` ensures could never be satisfied — TLC reported a real-looking property violation that was actually an extractor gap. Closes #147.

## What changed

The compound path (`state.foo += 1`) already preserves its RHS by capturing `right.getText()` and translating it downstream. The object-literal path now mirrors that:

- **Extractor** (`tools/analysis/src/extract/handlers.ts`): a translatable initializer — `BinaryExpression`, property/element access, parenthesized or unary forms — is captured as an `EXPR:<text>` marker (the same downstream `{ field, value }` shape the compound path produces). Call and conditional expressions are deliberately excluded (they translate unreliably) and, with literal/param forms still handled as before, anything left unhandled is surfaced as a `POLLY_DEBUG` warning instead of being silently dropped.
- **Codegen** (`tools/verify/src/codegen/tla.ts`): `assignmentValueToTLA` translates an `EXPR:` value via `tsExpressionToTLA`, so `sessionsMachine.value.outstanding + 1` flattens to `contextStates[ctx].sessionsMachine_outstanding + 1` — valid inside the EXCEPT clause (unprimed `contextStates` is the pre-state). `EXPR:` is deterministic, so it flows past the NDET-partition and payload-domain-provenance paths untouched.

Result: a bounded counter generates

```tla
contextStates' = [contextStates EXCEPT
  ![ctx].sessions_outstanding = contextStates[ctx].sessions_outstanding + 1]
```

instead of `UNCHANGED contextStates`, and its `EnsuresAfter_*` step-property is checkable again.

## Tests

- **Extractor** (`handler-object-literal-arithmetic.test.ts`, 6 cases): mint `+ 1`, revoke `- 1`, spread + arithmetic, plain field copy, and the negatives — literal RHS still a plain value, payload-parameter RHS still a `param:` marker (and not doubly-captured).
- **Integration** (`object-literal-arithmetic.test.ts`): composes the documented `analyzeCodebase` → `generateTLA` pipeline on a fixture and asserts the real EXCEPT appears and the handler is not an `UNCHANGED` stub — the seam where independently-green halves could still fail to compose.

analysis 92/92, verify 783/783, `tsc --noEmit` clean, biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)