### PR TITLE
feat(guards): add assertNever exhaustiveness helper (polly#142)

### DIFF
--- a/packages/polly/src/shared/lib/guards.ts
+++ b/packages/polly/src/shared/lib/guards.ts
@@ -34,3 +34,31 @@ export function hasKeyInObject<K extends string>(
 export function isRecord(input: unknown): input is Record<string, unknown> {
   return typeof input === "object" && input !== null && !Array.isArray(input);
 }
+
+/**
+ * Compile-time exhaustiveness check for discriminated unions.
+ *
+ * A string-literal union is decorative without one: add a third
+ * variant and nothing flags the `switch` statements that only handled
+ * the first two — the new case silently falls through whatever
+ * `default` arm exists. Placing `assertNever` in that `default` arm
+ * turns the gap into a type error, because `value` is only assignable
+ * to `never` when every other case has already been handled. The
+ * moment a variant is added and a switch forgets it, `value` is no
+ * longer `never` and the call fails to type-check.
+ *
+ * ```ts
+ * switch (event.kind) {
+ *   case "a": return handleA(event);
+ *   case "b": return handleB(event);
+ *   default: return assertNever(event);
+ * }
+ * ```
+ *
+ * The `throw` is the runtime backstop for the case TypeScript cannot
+ * see — a value arriving from outside the type system (a parsed JSON
+ * body, a `postMessage` payload) that violates the declared union.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`assertNever: unexpected value ${JSON.stringify(value)}`);
+}

--- a/packages/polly/tests/unit/guards.test.ts
+++ b/packages/polly/tests/unit/guards.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { hasKeyInObject, isRecord } from "@/shared/lib/guards";
+import { assertNever, hasKeyInObject, isRecord } from "@/shared/lib/guards";
 
 describe("isRecord", () => {
   test("returns true for plain objects", () => {
@@ -52,5 +52,42 @@ describe("hasKeyInObject", () => {
     expect(hasKeyInObject("string", "length")).toBe(false);
     expect(hasKeyInObject(42, "toString")).toBe(false);
     expect(hasKeyInObject(undefined, "a")).toBe(false);
+  });
+});
+
+describe("assertNever", () => {
+  type Shape = { kind: "a"; a: number } | { kind: "b"; b: string };
+
+  function describeShape(shape: Shape): string {
+    switch (shape.kind) {
+      case "a":
+        return `a:${shape.a}`;
+      case "b":
+        return `b:${shape.b}`;
+      default:
+        // Compiles only because every variant above is handled — `shape` is
+        // `never` here. This line is the exhaustiveness guarantee.
+        return assertNever(shape);
+    }
+  }
+
+  test("an exhaustive switch routes each variant without throwing", () => {
+    expect(describeShape({ kind: "a", a: 1 })).toBe("a:1");
+    expect(describeShape({ kind: "b", b: "x" })).toBe("b:x");
+  });
+
+  test("throws when reached at runtime with an out-of-union value", () => {
+    // A value smuggled past the type system (e.g. a malformed parsed payload).
+    const rogue = { kind: "c" } as unknown as never;
+    expect(() => assertNever(rogue)).toThrow(/unexpected value/);
+    expect(() => assertNever(rogue)).toThrow(/"kind":"c"/);
+  });
+
+  test("rejects a still-inhabited value at compile time", () => {
+    const stillB: { kind: "b" } = { kind: "b" };
+    // @ts-expect-error — `stillB` is not `never`, so the missing-case guard
+    // fires. If assertNever's parameter were widened, this directive would
+    // become unused and `tsc` (the project typecheck) would fail.
+    expect(() => assertNever(stillB)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Adds `assertNever(value: never): never` to `@fairfox/polly/guards`, alongside the existing type-system helpers (`isRecord`, `hasKeyInObject`). Closes #142.

A string-literal union is decorative without an exhaustiveness check — add a third variant and nothing flags the `switch` statements that only handled the first two; the new case silently falls through whatever `default` arm exists. Dropped into that `default` arm, `assertNever` turns the gap into a **compile-time** error, because `value` is only assignable to `never` once every other case has been handled:

```ts
switch (event.kind) {
  case "a": return handleA(event);
  case "b": return handleB(event);
  default: return assertNever(event); // type error the moment a variant is added and missed
}
```

The `throw` is the runtime backstop for a value that reaches the arm from outside the type system — a parsed JSON body or a `postMessage` payload that violates the declared union.

## Where it lives

`src/shared/lib/guards.ts`, already published as the `@fairfox/polly/guards` subpath export and already a build entrypoint, so no packaging changes are needed.

## Tests

Added to `tests/unit/guards.test.ts`:
- An exhaustive `switch` over a discriminated union routes each variant without throwing.
- The runtime backstop throws (with the offending value in the message) when reached via an out-of-union value.
- A **compile-time** test: `@ts-expect-error` on a call with a still-inhabited value. If the parameter were ever widened from `never`, the directive would become unused and `tsc` would fail — so the exhaustiveness contract is enforced by the typecheck, not just asserted in prose.

Full unit suite 958/958, `tsc --noEmit` clean (root + tests projects), biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)