### PR TITLE
fix(verify): write TLC state pool to a container-internal metadir

### DIFF
--- a/packages/polly/tools/verify/src/__tests__/runner/docker.test.ts
+++ b/packages/polly/tools/verify/src/__tests__/runner/docker.test.ts
@@ -142,5 +142,81 @@ describe("DockerRunner", () => {
         rmSyncSpy.mockRestore();
       }
     });
+
+    test("writes the state pool to a container-internal -metadir (#152)", async () => {
+      const docker = new DockerRunner();
+
+      let capturedArgs: string[] = [];
+
+      const runCommandSpy = spyOn(docker, "runCommand").mockImplementation(
+        async (_cmd: string, args: string[]) => {
+          capturedArgs = args;
+          return { exitCode: 0, stdout: "0 states generated", stderr: "" };
+        }
+      );
+
+      const existsSyncSpy = spyOn(fs, "existsSync").mockReturnValue(true);
+      const rmSyncSpy = spyOn(fs, "rmSync").mockImplementation(() => {
+        /* no-op mock */
+      });
+
+      try {
+        await docker.runTLC("/path/to/spec.tla", { workers: 1 });
+
+        // The state pool must be pointed off the host bind mount so it doesn't
+        // traverse Docker Desktop's file-share layer during large runs.
+        expect(capturedArgs).toContain("-metadir");
+        const metadirIndex = capturedArgs.indexOf("-metadir");
+        expect(capturedArgs[metadirIndex + 1]).toBe("/tmp/states");
+
+        // It must point at a container-internal path, never back into /work
+        // (the bind mount).
+        expect(capturedArgs[metadirIndex + 1]).not.toContain("/work");
+
+        // -metadir must come before the spec file, like the other TLC flags.
+        const specIndex = capturedArgs.indexOf("spec.tla");
+        expect(metadirIndex).toBeLessThan(specIndex);
+      } finally {
+        runCommandSpy.mockRestore();
+        existsSyncSpy.mockRestore();
+        rmSyncSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("parseTLCOutput", () => {
+    test("reports a state-pool IO flake distinctly from a spec error (#152)", async () => {
+      const docker = new DockerRunner();
+
+      const ioFailureOutput = [
+        "Error: when writing the disk (StatePoolWriter.run):",
+        "states/26-05-28-19-38-39/22403 (No such file or directory)",
+      ].join("\n");
+
+      const runCommandSpy = spyOn(docker, "runCommand").mockImplementation(async () => ({
+        exitCode: 1,
+        stdout: ioFailureOutput,
+        stderr: "",
+      }));
+
+      const existsSyncSpy = spyOn(fs, "existsSync").mockReturnValue(true);
+      const rmSyncSpy = spyOn(fs, "rmSync").mockImplementation(() => {
+        /* no-op mock */
+      });
+
+      try {
+        const result = await docker.runTLC("/path/to/spec.tla", { workers: 1 });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("state-pool IO failure");
+        expect(result.error).toContain("re-run");
+        // It must NOT be reported as a generic/spec error.
+        expect(result.error).not.toBe("Unknown error occurred during model checking");
+      } finally {
+        runCommandSpy.mockRestore();
+        existsSyncSpy.mockRestore();
+        rmSyncSpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/polly/tools/verify/src/runner/docker.ts
+++ b/packages/polly/tools/verify/src/runner/docker.ts
@@ -100,13 +100,25 @@ export class DockerRunner {
       throw new Error(`Config file not found: ${cfgPath}`);
     }
 
-    // Clean up any leftover state files from previous interrupted runs
+    // Clean up any leftover state files from previous interrupted runs.
+    // Older versions of the runner let TLC's -metadir default to
+    // <work>/states, so stale dirs may still exist on the host bind mount.
     const statesDir = path.join(specDir, "states");
     if (fs.existsSync(statesDir)) {
       fs.rmSync(statesDir, { recursive: true, force: true });
     }
 
-    // Run TLC in Docker
+    // Run TLC in Docker.
+    //
+    // -metadir points TLC's state pool at a container-internal path
+    // (/tmp/states on the overlay filesystem) instead of letting it default to
+    // <work>/states, which under our bind mount lands on the host via Docker
+    // Desktop's file-share layer (VirtioFS/osxfs). Large runs spill millions of
+    // small state-pool files; that layer isn't built for sustained small-file
+    // IO and surfaces transient "No such file or directory" mid-run failures.
+    // Keeping the state pool inside the container hits the native filesystem at
+    // native speed, and with --rm + -cleanup it dies with the container, so no
+    // multi-GB dirs leak back onto the host. See issue #152.
     const args = [
       "run",
       "--rm",
@@ -117,6 +129,8 @@ export class DockerRunner {
       "-workers",
       `${options?.workers || 1}`,
       "-cleanup", // Delete state files after model checking to prevent disk space issues
+      "-metadir",
+      "/tmp/states", // container-internal state pool, off the host bind mount (#152)
     ];
 
     // Add depth limit if maxDepth is configured (bounded model checking)
@@ -203,6 +217,16 @@ export class DockerRunner {
    * Extract error message from TLC output
    */
   private extractError(output: string): string {
+    // A state-pool write/read failing against a states/.../<n> path is almost
+    // never a real model problem — it's the Docker Desktop file-share layer
+    // dropping a small-file IO under sustained load. Since #152 we write the
+    // state pool to a container-internal -metadir, so this should no longer
+    // occur; if it does, point the consumer at the IO issue rather than letting
+    // them chase a phantom spec error.
+    if (/StatePool\w*\.run/.test(output) && /states\/.*No such file or directory/.test(output)) {
+      return "TLC state-pool IO failure (states/.../<n>: No such file or directory). This is a Docker filesystem flake, not a spec error — re-run the verification. See issue #152.";
+    }
+
     const errorMatch = output.match(/Error: (.*?)(?:\n|$)/);
     if (errorMatch?.[1]) {
       return errorMatch[1];


### PR DESCRIPTION
## Summary

Closes #152.

TLC's state pool defaulted to `<work>/states`, which under the docker runner's bind mount lands on the host via Docker Desktop's file-share layer. Large runs spill millions of small state-pool files through a layer that isn't built for that workload, surfacing as transient `No such file or directory` failures mid-run.

This passes `-metadir /tmp/states` so the state pool stays on the container's native overlay filesystem. Only the spec, cfg, and output log still cross the bind mount; with `--rm` and `-cleanup` the pool dies with the container, so nothing leaks back onto the host.

It also reports the state-pool IO signature distinctly: when TLC fails against a `states/.../<n>` path it is a filesystem flake to re-run, not a spec error to debug.