### PR TITLE
feat(verify): model-coverage report and --strict gate (polly#160)

### DIFF
--- a/packages/polly/tools/verify/src/__tests__/model-coverage-fixture.test.ts
+++ b/packages/polly/tools/verify/src/__tests__/model-coverage-fixture.test.ts
@@ -1,0 +1,69 @@
+// polly#160 (Ask #1) end-to-end (no Docker): drive the REAL analyzeCodebase
+// pipeline against the capability-guard fixture and read model coverage off the
+// extracted handlers. Proves the report works through the documented entry
+// point, not a hand-built handler list.
+//
+// Fixture shape (src/background/index.ts):
+//   AUTHENTICATE -> writes session.authenticated AND session.canSend
+//   REGISTER     -> writes session.canSend only (the bug)
+// Neither handler declares an ensures().
+
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { analyzeCodebase } from "../../../analysis/src";
+import { computeModelCoverage, strictCoverageReasons } from "../analysis/model-coverage";
+
+const projectPath = path.join(__dirname, "../../test-projects/capability-guard");
+const strictFixturePath = path.join(__dirname, "../../test-projects/coverage-strict");
+
+describe("model coverage on the capability-guard fixture (polly#160)", () => {
+  test("reports the uneven write distribution the scattered invariant produces", async () => {
+    const analysis = await analyzeCodebase({
+      tsConfigPath: path.join(projectPath, "tsconfig.json"),
+    });
+
+    const report = computeModelCoverage(
+      ["session.authenticated", "session.canSend"],
+      analysis.handlers
+    );
+
+    const byField = Object.fromEntries(report.fieldCoverage.map((f) => [f.field, f.writers]));
+    // authenticated is written by only the correct path; canSend by both —
+    // the "written by some paths but not others" signal.
+    expect(byField["session.authenticated"]).toEqual(["AUTHENTICATE"]);
+    expect(byField["session.canSend"]).toEqual(["AUTHENTICATE", "REGISTER"]);
+  });
+
+  test("the coverage-strict fixture: a declared field no handler writes fails strict", async () => {
+    // Purpose-built fixture: declares session.authenticated + session.canSend
+    // but the only handler (OPEN_GATE) writes canSend, leaving authenticated
+    // with no modelled mutating path — the omission class.
+    const analysis = await analyzeCodebase({
+      tsConfigPath: path.join(strictFixturePath, "tsconfig.json"),
+    });
+
+    const report = computeModelCoverage(
+      ["session.authenticated", "session.canSend"],
+      analysis.handlers
+    );
+
+    expect(report.unwrittenFields).toEqual(["session.authenticated"]);
+    expect(report.hasStrictViolation).toBe(true);
+    // The CLI's --strict gate would fail on exactly this.
+    expect(strictCoverageReasons(report, 0)).toHaveLength(1);
+  });
+
+  test("both fixture handlers are unconstrained mutators (no ensures())", async () => {
+    const analysis = await analyzeCodebase({
+      tsConfigPath: path.join(projectPath, "tsconfig.json"),
+    });
+
+    const report = computeModelCoverage(
+      ["session.authenticated", "session.canSend"],
+      analysis.handlers
+    );
+
+    const flagged = report.unconstrainedMutators.map((m) => m.handler).sort();
+    expect(flagged).toEqual(["AUTHENTICATE", "REGISTER"]);
+  });
+});

--- a/packages/polly/tools/verify/src/__tests__/model-coverage.test.ts
+++ b/packages/polly/tools/verify/src/__tests__/model-coverage.test.ts
@@ -1,0 +1,149 @@
+// polly#160 (Ask #1): model-coverage report unit tests.
+
+import { describe, expect, test } from "bun:test";
+import {
+  computeModelCoverage,
+  type ModelCoverageReport,
+  strictCoverageReasons,
+} from "../analysis/model-coverage";
+import type { MessageHandler } from "../types";
+
+function makeHandler(
+  messageType: string,
+  fields: string[],
+  opts: { ensures?: boolean } = {}
+): MessageHandler {
+  return {
+    messageType,
+    node: "test",
+    assignments: fields.map((field) => ({ field, value: "true" })),
+    preconditions: [],
+    postconditions: opts.ensures ? [{ expression: "true", location: { line: 1, column: 0 } }] : [],
+    location: { file: "test.ts", line: 1 },
+  };
+}
+
+describe("computeModelCoverage", () => {
+  test("reports which handlers write each declared field, in declaration order", () => {
+    const report = computeModelCoverage(
+      ["session.authenticated", "session.canSend"],
+      [
+        makeHandler("connect", ["session.authenticated"]),
+        makeHandler("authenticate", ["session.authenticated", "session.canSend"]),
+      ]
+    );
+    expect(report.fieldCoverage).toEqual([
+      { field: "session.authenticated", writers: ["authenticate", "connect"] },
+      { field: "session.canSend", writers: ["authenticate"] },
+    ]);
+  });
+
+  test("dedupes and sorts writers", () => {
+    const report = computeModelCoverage(
+      ["x"],
+      [makeHandler("b", ["x"]), makeHandler("a", ["x"]), makeHandler("a", ["x"])]
+    );
+    expect(report.fieldCoverage[0]?.writers).toEqual(["a", "b"]);
+  });
+
+  test("flags a declared field no handler writes, and sets the strict violation", () => {
+    const report = computeModelCoverage(
+      ["session.authenticated", "session.canSend"],
+      [makeHandler("connect", ["session.authenticated"])]
+    );
+    expect(report.unwrittenFields).toEqual(["session.canSend"]);
+    expect(report.hasStrictViolation).toBe(true);
+  });
+
+  test("no unwritten fields => no strict violation", () => {
+    const report = computeModelCoverage(["a", "b"], [makeHandler("h", ["a", "b"])]);
+    expect(report.unwrittenFields).toEqual([]);
+    expect(report.hasStrictViolation).toBe(false);
+  });
+
+  test("matches underscore config keys against dotted assignment fields", () => {
+    const report = computeModelCoverage(
+      ["user_loggedIn"],
+      [makeHandler("login", ["user.loggedIn"])]
+    );
+    expect(report.fieldCoverage[0]?.writers).toEqual(["login"]);
+    expect(report.unwrittenFields).toEqual([]);
+  });
+
+  test("flags a handler that mutates declared state with no ensures()", () => {
+    const report = computeModelCoverage(
+      ["session.canSend"],
+      [makeHandler("register", ["session.canSend"], { ensures: false })]
+    );
+    expect(report.unconstrainedMutators).toHaveLength(1);
+    expect(report.unconstrainedMutators[0]).toEqual({
+      handler: "register",
+      fields: ["session.canSend"],
+      location: { file: "test.ts", line: 1 },
+    });
+  });
+
+  test("a handler with an ensures() is not an unconstrained mutator", () => {
+    const report = computeModelCoverage(
+      ["session.canSend"],
+      [makeHandler("register", ["session.canSend"], { ensures: true })]
+    );
+    expect(report.unconstrainedMutators).toEqual([]);
+  });
+
+  test("ignores handler assignments to fields outside the declared schema", () => {
+    // A handler mutating only scratch (non-modelled) state is not an
+    // unconstrained mutator and contributes no writers.
+    const report = computeModelCoverage(
+      ["a"],
+      [makeHandler("h", ["scratch.tmp"], { ensures: false })]
+    );
+    expect(report.unconstrainedMutators).toEqual([]);
+    expect(report.unwrittenFields).toEqual(["a"]);
+  });
+
+  test("empty handler set => every declared field is unwritten", () => {
+    const report = computeModelCoverage(["a", "b"], []);
+    expect(report.unwrittenFields).toEqual(["a", "b"]);
+    expect(report.hasStrictViolation).toBe(true);
+  });
+});
+
+function reportWith(overrides: Partial<ModelCoverageReport>): ModelCoverageReport {
+  return {
+    fieldCoverage: [],
+    unwrittenFields: [],
+    unconstrainedMutators: [],
+    hasStrictViolation: false,
+    ...overrides,
+  };
+}
+
+describe("strictCoverageReasons", () => {
+  test("clean report with no mesh findings => no reasons (strict passes)", () => {
+    expect(strictCoverageReasons(reportWith({}), 0)).toEqual([]);
+  });
+
+  test("an unwritten field is a strict reason", () => {
+    const reasons = strictCoverageReasons(
+      reportWith({ unwrittenFields: ["session.authenticated"], hasStrictViolation: true }),
+      0
+    );
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain("1 declared state field");
+  });
+
+  test("unverified mesh/peer predicates are a strict reason", () => {
+    const reasons = strictCoverageReasons(reportWith({}), 2);
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain("2 unverified");
+  });
+
+  test("both gaps produce both reasons", () => {
+    const reasons = strictCoverageReasons(
+      reportWith({ unwrittenFields: ["x"], hasStrictViolation: true }),
+      1
+    );
+    expect(reasons).toHaveLength(2);
+  });
+});

--- a/packages/polly/tools/verify/src/analysis/model-coverage.ts
+++ b/packages/polly/tools/verify/src/analysis/model-coverage.ts
@@ -1,0 +1,150 @@
+// polly#160 (Ask #1): model-coverage report — surface what the model does NOT
+// cover instead of dropping it silently.
+//
+// The motivating bug (a capability granted by a path the model never sees) is an
+// OMISSION: a statement never written, a transition never modelled. Mutation
+// testing is blind to it (no line to mutate) and a green TLC run says nothing
+// about a field no handler touches. This module reads the analyzed handler
+// surface against the declared state schema and reports three things:
+//
+//   1. write distribution — for each declared state field, which handlers
+//      assign it (the "written by some paths but not others" signal: the
+//      scattered-invariant smell shows up as an uneven writer set).
+//   2. unwritten fields — declared state fields NO modelled handler assigns.
+//      The model carries a variable no transition can ever change: either dead
+//      state inflating the state space, or — the dangerous case — a field whose
+//      real mutating path was never modelled (e.g. a `register()` that escapes
+//      the message-handler surface). This is the soundest static proxy for the
+//      omission bug, so it is the `--strict` fail-closed trigger.
+//   3. unconstrained mutators — handlers that mutate declared state but pin no
+//      `ensures()` postcondition. The checker explores the transition but
+//      asserts nothing about its effect. Reported as a hint (ensures is
+//      optional by design), never a strict failure.
+//
+// `analysis.handlers` contains only handlers whose message type is representable
+// in TLA+; the unrepresentable ones (polly#144) are filtered upstream and warned
+// unconditionally there, so they are not re-reported here.
+
+import type { MessageHandler } from "../types";
+
+/** Per declared field: the message types of every handler that assigns it. */
+export type FieldWriteCoverage = {
+  /** The declared (config) field name, canonical dot-form. */
+  field: string;
+  /** Message types of handlers that write this field (sorted, de-duplicated). */
+  writers: string[];
+};
+
+/** A handler that mutates declared state but states no postcondition. */
+export type UnconstrainedMutator = {
+  /** The handler's message type. */
+  handler: string;
+  /** Declared fields this handler assigns. */
+  fields: string[];
+  /** Source location of the handler. */
+  location: { file: string; line: number };
+};
+
+export type ModelCoverageReport = {
+  /** Write distribution for every declared field, in declaration order. */
+  fieldCoverage: FieldWriteCoverage[];
+  /** Declared fields no modelled handler assigns. */
+  unwrittenFields: string[];
+  /** Handlers that mutate declared state with no `ensures()` postcondition. */
+  unconstrainedMutators: UnconstrainedMutator[];
+  /**
+   * True when the model has a coverage gap worth failing `--strict` on. Gated
+   * on `unwrittenFields` only: a declared-but-unwritten field is an unambiguous
+   * "the model cannot exercise this" signal. Unconstrained mutators are a soft
+   * hint and never set this.
+   */
+  hasStrictViolation: boolean;
+};
+
+/** Canonical dot-form so a config field name and a handler assignment field
+ *  compare equal regardless of underscore/dot form (assignments are dotted
+ *  "user.loggedIn"; config keys may be underscore "user_loggedIn"). Mirrors
+ *  the matcher in coupled-fields.ts. */
+function norm(field: string): string {
+  return field.replace(/_/g, ".");
+}
+
+/**
+ * Compute model coverage of the declared state schema by the analyzed handler
+ * surface. `stateFields` are the keys of the verification config's `state`
+ * block; `handlers` is `analysis.handlers` (already filtered to representable
+ * message types upstream).
+ */
+export function computeModelCoverage(
+  stateFields: string[],
+  handlers: MessageHandler[]
+): ModelCoverageReport {
+  // declared field (normalised) -> set of writer message types
+  const writersByField = new Map<string, Set<string>>();
+  for (const field of stateFields) {
+    writersByField.set(norm(field), new Set());
+  }
+
+  // declared field (normalised) -> original config name, preserving order
+  const declaredOrder = stateFields.map((f) => ({ raw: f, key: norm(f) }));
+
+  for (const handler of handlers) {
+    for (const assignment of handler.assignments) {
+      const key = norm(assignment.field);
+      const writers = writersByField.get(key);
+      if (writers) writers.add(handler.messageType);
+    }
+  }
+
+  const fieldCoverage: FieldWriteCoverage[] = declaredOrder.map(({ raw, key }) => ({
+    field: raw,
+    writers: Array.from(writersByField.get(key) ?? []).sort(),
+  }));
+
+  const unwrittenFields = fieldCoverage.filter((f) => f.writers.length === 0).map((f) => f.field);
+
+  const declaredKeys = new Set(declaredOrder.map((d) => d.key));
+  const unconstrainedMutators: UnconstrainedMutator[] = [];
+  for (const handler of handlers) {
+    if (handler.postconditions.length > 0) continue;
+    const fields = Array.from(
+      new Set(handler.assignments.map((a) => norm(a.field)).filter((f) => declaredKeys.has(f)))
+    ).sort();
+    if (fields.length > 0) {
+      unconstrainedMutators.push({
+        handler: handler.messageType,
+        fields,
+        location: handler.location,
+      });
+    }
+  }
+
+  return {
+    fieldCoverage,
+    unwrittenFields,
+    unconstrainedMutators,
+    hasStrictViolation: unwrittenFields.length > 0,
+  };
+}
+
+/**
+ * The reasons a `--strict` run should fail closed: an unwritten declared field
+ * (a modelled-but-unreachable mutation — the omission class) and/or unverified
+ * `$meshState`/`$peerState` predicates (polly#117). Empty array means strict
+ * passes. Pure so the CLI's exit decision is testable apart from `process.exit`.
+ */
+export function strictCoverageReasons(
+  report: ModelCoverageReport,
+  meshFindingCount: number
+): string[] {
+  const reasons: string[] = [];
+  if (report.hasStrictViolation) {
+    reasons.push(
+      `${report.unwrittenFields.length} declared state field(s) written by no modelled handler`
+    );
+  }
+  if (meshFindingCount > 0) {
+    reasons.push(`${meshFindingCount} unverified $meshState/$peerState predicate(s)`);
+  }
+  return reasons;
+}

--- a/packages/polly/tools/verify/src/cli.ts
+++ b/packages/polly/tools/verify/src/cli.ts
@@ -363,9 +363,9 @@ function displayExpressionWarnings(result: ValidationResult): void {
 function displayMeshOrPeerSignalWarnings(
   analysis: import("./core/model").CodebaseAnalysis,
   declaredMeshDocs: ReadonlySet<string>
-): void {
+): number {
   const findings = computeMeshOrPeerSignalFindings(analysis, declaredMeshDocs);
-  if (findings.length === 0) return;
+  if (findings.length === 0) return 0;
 
   const hasUndeclaredMesh = findings.some((f) => f.signalKind === "mesh");
   const hasPeer = findings.some((f) => f.signalKind === "peer");
@@ -418,6 +418,133 @@ function displayMeshOrPeerSignalWarnings(
     console.log(color(`      at ${f.location.file}:${f.location.line}`, COLORS.gray));
     console.log();
   }
+
+  return findings.length;
+}
+
+/**
+ * polly#160 (Ask #1): does the operator want a fail-closed run? `--strict`
+ * (or POLLY_VERIFY_STRICT=1) turns model-coverage gaps and unverified
+ * mesh/peer signals from warnings into a non-zero exit, so a silently
+ * unmodelled path cannot pass with a green check.
+ */
+function isStrictMode(): boolean {
+  return process.argv.includes("--strict") || process.env.POLLY_VERIFY_STRICT === "1";
+}
+
+/**
+ * polly#160 (Ask #1): render the model-coverage report — which declared state
+ * fields are written by which handlers, which are written by none, and which
+ * mutators pin no postcondition. Clean specs get a one-line confirmation.
+ */
+function displayModelCoverage(
+  report: import("./analysis/model-coverage").ModelCoverageReport
+): void {
+  const { unwrittenFields, unconstrainedMutators, fieldCoverage } = report;
+
+  if (unwrittenFields.length === 0 && unconstrainedMutators.length === 0) {
+    console.log(
+      color(
+        `✓ Model coverage: all ${fieldCoverage.length} declared field(s) written by a modelled handler`,
+        COLORS.green
+      )
+    );
+    console.log();
+    return;
+  }
+
+  if (unwrittenFields.length > 0) {
+    console.log(
+      color(
+        `\n⚠️  ${unwrittenFields.length} declared state field(s) written by NO modelled handler (polly#160):`,
+        COLORS.yellow
+      )
+    );
+    for (const f of unwrittenFields) {
+      console.log(color(`   • ${f}`, COLORS.yellow));
+    }
+    console.log(
+      color(
+        "   The model carries a variable no transition can change. Either it is dead",
+        COLORS.gray
+      )
+    );
+    console.log(
+      color(
+        "   state (drop it from the verified surface) or its mutating path was never",
+        COLORS.gray
+      )
+    );
+    console.log(
+      color("   modelled — the omission class both TLC and mutation testing miss.", COLORS.gray)
+    );
+    console.log();
+  }
+
+  if (unconstrainedMutators.length > 0) {
+    console.log(
+      color(
+        `ℹ️  ${unconstrainedMutators.length} handler(s) mutate declared state with no ensures() postcondition:`,
+        COLORS.gray
+      )
+    );
+    for (const m of unconstrainedMutators) {
+      console.log(
+        color(
+          `   • ${m.handler} writes {${m.fields.join(", ")}} — ${m.location.file}:${m.location.line}`,
+          COLORS.gray
+        )
+      );
+    }
+    console.log(
+      color(
+        "   The checker explores these transitions but asserts nothing about their effect.",
+        COLORS.gray
+      )
+    );
+    console.log();
+  }
+}
+
+/**
+ * polly#160 (Ask #1): compute and render the model-coverage report, then —
+ * under --strict — fail closed before the expensive TLC pass when the model
+ * has an unwritten declared field or an unverified mesh/peer signal. Extracted
+ * from runFullVerification to keep that orchestrator within complexity limits.
+ */
+async function runModelCoverage(
+  typedConfig: UnifiedVerificationConfig,
+  typedAnalysis: import("./core/model").CodebaseAnalysis,
+  meshFindingCount: number
+): Promise<void> {
+  const { computeModelCoverage, strictCoverageReasons } = await import("./analysis/model-coverage");
+  const stateFields = Object.keys((typedConfig as { state?: Record<string, unknown> }).state ?? {});
+  const coverage = computeModelCoverage(stateFields, typedAnalysis.handlers);
+  displayModelCoverage(coverage);
+
+  if (!isStrictMode()) return;
+
+  const reasons = strictCoverageReasons(coverage, meshFindingCount);
+
+  if (reasons.length === 0) {
+    console.log(color("✓ Strict mode: model coverage complete", COLORS.green));
+    console.log();
+    return;
+  }
+
+  console.log(color("❌ Strict mode: model coverage incomplete\n", COLORS.red));
+  for (const reason of reasons) {
+    console.log(color(`   • ${reason}`, COLORS.red));
+  }
+  console.log();
+  console.log(
+    color("   --strict fails closed on these so an unmodelled path cannot pass with a", COLORS.gray)
+  );
+  console.log(
+    color("   green check. Re-run without --strict to treat them as warnings.", COLORS.gray)
+  );
+  console.log();
+  process.exit(1);
 }
 
 async function verifyCommand() {
@@ -586,11 +713,14 @@ async function runFullVerification(configPath: string) {
   const declaredMeshDocs = new Set(
     Object.keys((typedConfig as { mesh?: Record<string, unknown> }).mesh ?? {})
   );
-  displayMeshOrPeerSignalWarnings(typedAnalysis, declaredMeshDocs);
+  const meshFindingCount = displayMeshOrPeerSignalWarnings(typedAnalysis, declaredMeshDocs);
 
   // polly#160: coupled-field write-coupling lint (warn-only). One call here
   // covers both the subsystem and monolithic paths below.
   await runCoupledFieldsLint(typedConfig, typedAnalysis);
+
+  // polly#160 (Ask #1): model-coverage report + optional fail-closed gate.
+  await runModelCoverage(typedConfig, typedAnalysis, meshFindingCount);
 
   // Check for subsystem-scoped verification
   if (typedConfig.subsystems && Object.keys(typedConfig.subsystems).length > 0) {
@@ -1233,6 +1363,11 @@ ${color("Commands:", COLORS.blue)}
 
   ${color("bun verify", COLORS.green)}
     Run verification (validates config, generates specs, runs TLC)
+
+  ${color("bun verify --strict", COLORS.green)}
+    Fail closed (non-zero exit) on model-coverage gaps: a declared state
+    field no handler writes, or an unverified $meshState/$peerState predicate.
+    Also via ${color("POLLY_VERIFY_STRICT=1", COLORS.yellow)}.
 
   ${color("bun verify --setup", COLORS.green)}
     Analyze codebase and generate configuration file

--- a/packages/polly/tools/verify/test-projects/coverage-strict/package.json
+++ b/packages/polly/tools/verify/test-projects/coverage-strict/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-coverage-strict",
+  "version": "1.0.0",
+  "description": "Verify fixture (polly#160 Ask #1): a declared state field with no modelled writer; `polly verify --strict` must fail closed.",
+  "main": "src/background/index.ts"
+}

--- a/packages/polly/tools/verify/test-projects/coverage-strict/specs/verification.config.ts
+++ b/packages/polly/tools/verify/test-projects/coverage-strict/specs/verification.config.ts
@@ -1,0 +1,20 @@
+// Verification config for the coverage-strict fixture (polly#160 Ask #1).
+//
+// Declares two state fields; the fixture's only handler writes `canSend`,
+// leaving `authenticated` written by no modelled handler. Running
+// `polly verify --strict` against this project fails closed at the
+// model-coverage gate, before the TLC pass.
+
+import { defineVerification } from "@fairfox/polly/verify";
+
+export const verificationConfig = defineVerification({
+  state: {
+    "session.authenticated": { type: "boolean" },
+    "session.canSend": { type: "boolean" },
+  },
+
+  messages: {
+    maxInFlight: 1,
+    maxTabs: 1,
+  },
+});

--- a/packages/polly/tools/verify/test-projects/coverage-strict/src/background/index.ts
+++ b/packages/polly/tools/verify/test-projects/coverage-strict/src/background/index.ts
@@ -1,0 +1,23 @@
+// Verify fixture for polly#160 (Ask #1): a declared state field that NO handler
+// writes. The config declares `session.authenticated` and `session.canSend`,
+// but only `canSend` is ever assigned — `authenticated` has no modelled mutating
+// path. `polly verify --strict` must fail closed on it.
+
+import { createBackground } from "@fairfox/polly/background";
+import { $sharedState } from "@fairfox/polly/state";
+
+export const session = $sharedState("session", {
+  authenticated: false,
+  canSend: false,
+});
+
+const bus = createBackground();
+
+// Writes canSend only. `authenticated` is declared but never assigned anywhere —
+// the omission class the coverage report surfaces.
+bus.on("OPEN_GATE", async () => {
+  session.value.canSend = true;
+  return { ok: true };
+});
+
+console.log("coverage-strict fixture loaded");

--- a/packages/polly/tools/verify/test-projects/coverage-strict/tsconfig.json
+++ b/packages/polly/tools/verify/test-projects/coverage-strict/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #160.

## Why

The motivating bug in #160 is an **omission**: a capability granted by a path the model never sees. Mutation testing cannot find it — there is no line to mutate — and a green TLC run says nothing about a field no handler writes. The capability invariant from `b4fa0f8` already catches the coupled-field case (Ask #2). This delivers the rest of Ask #1: surfacing what the model does **not** cover, instead of dropping it silently.

The "warn loudly on silent drops" half of Ask #1 turned out to be largely in place already — #144 throws and warns upstream, #147 is translated rather than dropped, and #117 already warns — so the genuinely missing piece was the coverage report itself.

## What

- **`src/analysis/model-coverage.ts`** — `computeModelCoverage(stateFields, handlers)` reads the analysed handler surface against the declared state schema and reports three things:
  - **write distribution** per declared field — which handlers write it (the "written by some paths but not others" signal);
  - **unwritten fields** — declared state no modelled handler assigns (the omission class);
  - **unconstrained mutators** — handlers that mutate state but pin no `ensures()`.
  - `strictCoverageReasons()` is the pure strict-gate decision, kept separate from the exit so it is testable.
- **`src/cli.ts`** — `polly verify` renders the report (a green one-liner when clean). `--strict` (or `POLLY_VERIFY_STRICT=1`) fails closed **before** the Docker/TLC pass when a declared field has no writer or a `$meshState`/`$peerState` predicate is unverified, so an unmodelled path can no longer pass with a green check. `--help` documents the flag.

## Boundary

The report covers the message-handler surface. A non-dispatched mutator function that escapes the extractor entirely (the literal `register()` shape) is an extractor-reach limitation, noted in the module header, not something this layer can see.

## Tests

13 unit tests and 3 real-pipeline integration tests driving the actual `analyzeCodebase` extractor against the `capability-guard` and a new purpose-built `coverage-strict` fixture. Full verify suite 820 pass / 0 fail; lint and typecheck clean.

## Acceptance criteria (#160)

- [x] `polly verify` reports modelled-vs-unmodelled state-mutating paths
- [x] capability-without-precondition fails verification with a counterexample (shipped earlier in `b4fa0f8`)
- [x] #144/#147/#117-class omissions surface as warnings, and now fail closed under `--strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)