### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Link the issue this PR resolves with a closing keyword so it closes on merge:
+
+  Closes #123
+
+Without it the issue stays open after merge — the recurring miss this template
+exists to prevent. Use "Closes"/"Fixes" for each issue this fully resolves, or
+"Refs #123" for one it only touches.
+-->
+
+Closes #
+
+## Why
+
+<!-- The problem or motivation. What was wrong, or what is now possible. -->
+
+## What
+
+<!-- The change, at the altitude a reviewer needs. Lead with the load-bearing
+parts; leave mechanical detail to the diff. -->
+
+## Notes
+
+<!-- Anything a reviewer should weigh: a deliberate trade-off, a boundary left
+unhandled (link the follow-up issue), a risk worth a second look. Delete if
+there is nothing to add. -->


### PR DESCRIPTION
## Why

Three issues this cycle — #138, #155, #124 — stayed open after their work had merged, only because the merge commits carried no `Closes #NNN` keyword. The link was an afterthought, so it got skipped.

## What

Adds `.github/pull_request_template.md`. `Closes #` sits at the very top, with a comment explaining why the keyword matters, so linking the issue is the default rather than something to remember. The Why / What / Notes sections mirror how PRs are already written here, and the template deliberately omits any test-steps section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)